### PR TITLE
fix: enforce project-level authorization

### DIFF
--- a/__tests__/controllers/errorFormatterController.test.ts
+++ b/__tests__/controllers/errorFormatterController.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import { errorFormatterController } from "@/controllers/errorFormatterController";
+import { ProjectAccessError } from "@/services/projectAccessService";
+import { createMockRequest, createMockResponse } from "@/test-utils/httpMocks";
+
+jest.mock("@/services/errorFormatterService", () => ({
+  errorFormatterService: {
+    suggestFromResult: jest.fn(),
+  },
+}));
+
+jest.mock("@/services/projectAccessService", () => {
+  class MockProjectAccessError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message);
+      this.name = "ProjectAccessError";
+    }
+  }
+
+  return {
+    ProjectAccessError: MockProjectAccessError,
+    projectAccessService: {
+      assertResultAccess: jest.fn(),
+    },
+  };
+});
+
+describe("errorFormatterController.suggestFromResult", () => {
+  const errorFormatterServiceMock: {
+    errorFormatterService: {
+      suggestFromResult: jest.Mock;
+    };
+  } = jest.requireMock("@/services/errorFormatterService");
+
+  const projectAccessServiceMock: {
+    projectAccessService: {
+      assertResultAccess: jest.Mock;
+    };
+  } = jest.requireMock("@/services/projectAccessService");
+
+  const user = {
+    id: "24de2184-e32b-4a88-b119-0f67d34496f1",
+    name: "Owner",
+    email: "owner@ventionteams.com",
+    status: "active" as const,
+    role: "member" as const,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  };
+
+  const body = {
+    resultId: "52073d0a-737f-4ecb-82ef-54fc040e6bfe",
+    projectId: "0469e889-aa5d-4a12-9310-22b8aaed816e",
+  };
+
+  const assertResultAccessMock = projectAccessServiceMock.projectAccessService
+    .assertResultAccess as jest.MockedFunction<
+    (typeof projectAccessServiceMock.projectAccessService)["assertResultAccess"]
+  >;
+  const suggestFromResultMock = errorFormatterServiceMock.errorFormatterService
+    .suggestFromResult as jest.MockedFunction<
+    (typeof errorFormatterServiceMock.errorFormatterService)["suggestFromResult"]
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("checks result project access before generating an AI suggestion", async () => {
+    assertResultAccessMock.mockImplementation(async () => undefined);
+    suggestFromResultMock.mockImplementation(async () => ({
+      category: "bug",
+      description: "Suggested fix",
+    }));
+
+    const req = createMockRequest({ method: "POST", body, user });
+    const res = createMockResponse();
+
+    await errorFormatterController.suggestFromResult(req, res);
+
+    expect(
+      projectAccessServiceMock.projectAccessService.assertResultAccess,
+    ).toHaveBeenCalledWith(user, body.resultId);
+    expect(
+      errorFormatterServiceMock.errorFormatterService.suggestFromResult,
+    ).toHaveBeenCalledWith(body.resultId, body.projectId);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("does not generate an AI suggestion when result access is denied", async () => {
+    assertResultAccessMock.mockImplementation(async () => {
+      throw new ProjectAccessError("Project access denied", 403);
+    });
+
+    const req = createMockRequest({ method: "POST", body, user });
+    const res = createMockResponse();
+
+    await errorFormatterController.suggestFromResult(req, res);
+
+    expect(
+      errorFormatterServiceMock.errorFormatterService.suggestFromResult,
+    ).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Project access denied" });
+  });
+});

--- a/__tests__/routes/issue.test.ts
+++ b/__tests__/routes/issue.test.ts
@@ -115,6 +115,22 @@ jest.mock("@/models/issueModel", () => ({
   },
 }));
 
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    findById: jest.fn((id: string) => {
+      const owner = users[0];
+      return Promise.resolve(
+        owner
+          ? {
+              id,
+              ownerId: owner.id,
+            }
+          : null,
+      );
+    }),
+  },
+}));
+
 describe("v2 issues auth flow", () => {
   beforeEach(() => {
     users.length = 0;

--- a/__tests__/services/projectAccessService.test.ts
+++ b/__tests__/services/projectAccessService.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import { projectModel } from "@/models/projectModel";
+import { projectAccessService } from "@/services/projectAccessService";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+
+jest.mock("@/models/projectModel");
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    issue: {
+      findUnique: jest.fn(),
+    },
+    result: {
+      findUnique: jest.fn(),
+    },
+    resultError: {
+      findUnique: jest.fn(),
+    },
+    assumption: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+const mockProjectModel = projectModel as jest.Mocked<typeof projectModel>;
+
+const user = (
+  id: string,
+  role: "admin" | "member" = "member",
+): NonNullable<AuthenticatedRequest["user"]> => ({
+  id,
+  role,
+  status: "active",
+  name: `${id} name`,
+  email: `${id}@example.com`,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+describe("projectAccessService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("allows the project owner to access a project", async () => {
+    mockProjectModel.findById.mockResolvedValue({
+      id: "project-a",
+      ownerId: "user-a",
+    } as Awaited<ReturnType<typeof projectModel.findById>>);
+
+    await expect(
+      projectAccessService.assertProjectAccess(user("user-a"), "project-a"),
+    ).resolves.toEqual(expect.objectContaining({ id: "project-a" }));
+  });
+
+  it("denies a different member access to the project", async () => {
+    mockProjectModel.findById.mockResolvedValue({
+      id: "project-a",
+      ownerId: "user-a",
+    } as Awaited<ReturnType<typeof projectModel.findById>>);
+
+    await expect(
+      projectAccessService.assertProjectAccess(user("user-b"), "project-a"),
+    ).rejects.toMatchObject({
+      message: "Project access denied",
+      statusCode: 403,
+    });
+  });
+
+  it("allows admin users to access projects they do not own", async () => {
+    mockProjectModel.findById.mockResolvedValue({
+      id: "project-a",
+      ownerId: "user-a",
+    } as Awaited<ReturnType<typeof projectModel.findById>>);
+
+    await expect(
+      projectAccessService.assertProjectAccess(
+        user("admin-user", "admin"),
+        "project-a",
+      ),
+    ).resolves.toEqual(expect.objectContaining({ id: "project-a" }));
+  });
+
+  it("filters project lists by owner for non-admin users", () => {
+    expect(projectAccessService.projectFilterForUser(user("user-a"))).toEqual({
+      ownerId: "user-a",
+    });
+  });
+});

--- a/__tests__/services/uploadApiKeyService.security.test.ts
+++ b/__tests__/services/uploadApiKeyService.security.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import crypto from "crypto";
+import { uploadApiKeyModel } from "@/models/uploadApiKeyModel";
+import { uploadApiKeyService } from "@/services/uploadApiKeyService";
+
+jest.mock("@/models/uploadApiKeyModel");
+
+const mockUploadApiKeyModel = uploadApiKeyModel as jest.Mocked<
+  typeof uploadApiKeyModel
+>;
+
+function signedUploadKey(params: {
+  keyId: string;
+  projectId: string;
+  ownerId: string;
+  secret: string;
+}): string {
+  const payload = `upload_${params.keyId}_${params.projectId}_${params.ownerId}_1780000000000_abcdef`;
+  const signature = crypto
+    .createHmac("sha256", params.secret)
+    .update(payload)
+    .digest("hex");
+
+  return `${payload}.${signature}`;
+}
+
+describe("uploadApiKeyService security", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.API_KEY_SECRET = "test-api-key-secret";
+  });
+
+  afterEach(() => {
+    delete process.env.API_KEY_SECRET;
+  });
+
+  it("rejects a signed upload key when payload project/owner do not match the stored key record", async () => {
+    const keyId = "11111111-1111-4111-8111-111111111111";
+    const forgedKey = signedUploadKey({
+      keyId,
+      projectId: "22222222-2222-4222-8222-222222222222",
+      ownerId: "33333333-3333-4333-8333-333333333333",
+      secret: process.env.API_KEY_SECRET as string,
+    });
+
+    mockUploadApiKeyModel.findById.mockResolvedValue({
+      id: keyId,
+      projectId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      ownerId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      isActive: true,
+    } as Awaited<ReturnType<typeof uploadApiKeyModel.findById>>);
+
+    await expect(uploadApiKeyService.validateApiKey(forgedKey)).rejects.toThrow(
+      "API key payload does not match stored key record",
+    );
+  });
+});

--- a/src/controllers/assumptionController.ts
+++ b/src/controllers/assumptionController.ts
@@ -1,16 +1,21 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { assumptionService } from "@/services/assumptionService";
 import type { CreateAssumptionRequest, UpdateAssumptionRequest } from "@/types";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 type AssumptionIdParams = {
   assumptionId: string;
 };
 
 export const assumptionController = {
-  createAssumption: async (req: Request, res: Response): Promise<void> => {
+  createAssumption: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const assumptionData: CreateAssumptionRequest = req.body;
 
@@ -21,19 +26,27 @@ export const assumptionController = {
         return;
       }
 
+      await projectAccessService.assertIssueAccess(req.user, assumptionData.issueId);
+      if (assumptionData.resultErrorId) {
+        await projectAccessService.assertResultErrorAccess(
+          req.user,
+          assumptionData.resultErrorId,
+        );
+      }
+
       const assumption =
         await assumptionService.createAssumption(assumptionData);
       res.status(201).json(assumption);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to create assumption. ${err.message}`,
       });
     }
   },
 
   updateAssumption: async (
-    req: Request<AssumptionIdParams>,
+    req: AuthenticatedRequest<AssumptionIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -54,6 +67,8 @@ export const assumptionController = {
         return;
       }
 
+      await projectAccessService.assertAssumptionAccess(req.user, assumptionId);
+
       const result = await assumptionService.updateAssumption(
         assumptionId,
         updateData,
@@ -66,14 +81,14 @@ export const assumptionController = {
       }
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to update assumption. ${err.message}`,
       });
     }
   },
 
   getAssumptionById: async (
-    req: Request<AssumptionIdParams>,
+    req: AuthenticatedRequest<AssumptionIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -94,19 +109,24 @@ export const assumptionController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(
+        req.user,
+        projectId as string,
+      );
+
       const assumption =
         await assumptionService.getAssumptionById(assumptionId, projectId as string);
       res.status(200).json(assumption);
     } catch (error) {
       const err = error as Error;
-      res.status(404).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 404).json({
         error: err.message,
       });
     }
   },
 
   deleteAssumption: async (
-    req: Request<AssumptionIdParams>,
+    req: AuthenticatedRequest<AssumptionIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -127,10 +147,19 @@ export const assumptionController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       await assumptionService.deleteAssumption(assumptionId, projectId);
       res.status(204).send();
     } catch (error) {
       const err = error as Error;
+
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: err.message,
+        });
+        return;
+      }
 
       if (err.message.includes("not found")) {
         res.status(404).json({

--- a/src/controllers/ctrfController.ts
+++ b/src/controllers/ctrfController.ts
@@ -1,12 +1,17 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Request, Response } from "express";
+import type { Response } from "express";
 import { ctrfService } from "@/services/ctrfService";
 import type { CTRFReport } from "@/types/ctrf";
 import type { ApiKeyAuthenticatedRequest } from "@/middleware/apiKeyMiddleware";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
 import type { ProcessReportResult } from "@/services/jsonReportService";
 import getLogger from "@/lib/logger";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const logger = getLogger("ctrf-controller");
 
@@ -58,10 +63,14 @@ export const ctrfController = {
     return result;
   },
 
-  async processRawReportFile(req: Request, res: Response): Promise<void> {
+  async processRawReportFile(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
       // Extract projectId from form data (multipart form upload)
       const projectId = req.body.projectId;
+
+      if (projectId) {
+        await projectAccessService.assertProjectAccess(req.user, projectId);
+      }
 
       const response = await ctrfController._processRawReportFileCore(
         req.file,
@@ -71,7 +80,7 @@ export const ctrfController = {
       res.status(201).json(response);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to process raw CTRF report file. ${err.message}`,
       });
     }

--- a/src/controllers/dashboardController.ts
+++ b/src/controllers/dashboardController.ts
@@ -5,6 +5,11 @@ import type { Response, Request } from "express";
 import { dashboardService } from "@/services/dashboardService";
 import type { DashboardGranularity } from "@/types/dashboard";
 import getLogger from "@/lib/logger";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const logger = getLogger("dashboard-controller");
 
@@ -49,12 +54,14 @@ export const dashboardController = {
    * Query Params: environment (string), period (number of days, default 30), type (string, optional)
    */
   async getDashboard(
-    req: Request<DashboardParams>,
+    req: AuthenticatedRequest<DashboardParams>,
     res: Response,
   ): Promise<void> {
     try {
       const { projectId, environment, periodDays, executionType, granularity } =
         parseDashboardParams(req);
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
 
       const dashboardData = await dashboardService.getDashboard(
         projectId,
@@ -76,6 +83,10 @@ export const dashboardController = {
         }
       }
       logger.error("Error fetching dashboard data", error);
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({ error: error.message });
+        return;
+      }
       res.status(500).json({ error: "Failed to fetch dashboard data" });
     }
   },

--- a/src/controllers/errorFormatterController.ts
+++ b/src/controllers/errorFormatterController.ts
@@ -3,7 +3,12 @@
 
 import { Request, Response } from "express";
 import { z } from "zod";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
 import { errorFormatterService } from "@/services/errorFormatterService";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const ErrorMessageSchema = z.object({
   name: z.string().min(1, "Name cannot be empty").max(100, "Name is too long"),
@@ -54,7 +59,10 @@ export const errorFormatterController = {
     }
   },
 
-  suggestFromResult: async (req: Request, res: Response): Promise<void> => {
+  suggestFromResult: async (
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<void> => {
     try {
       const validation = ErrorSuggestionSchema.safeParse(req.body);
 
@@ -67,6 +75,7 @@ export const errorFormatterController = {
       }
 
       const { resultId, projectId } = validation.data;
+      await projectAccessService.assertResultAccess(req.user, resultId);
       const suggestion = await errorFormatterService.suggestFromResult(
         resultId,
         projectId,
@@ -80,7 +89,13 @@ export const errorFormatterController = {
         err.message.includes("failed or flaky") ||
         err.message.includes("no error details");
 
-      res.status(isValidationError ? 400 : 500).json({
+      res.status(
+        error instanceof ProjectAccessError
+          ? error.statusCode
+          : isValidationError
+            ? 400
+            : 500,
+      ).json({
         error: err.message || "Failed to generate suggestion",
       });
     }

--- a/src/controllers/executionController.ts
+++ b/src/controllers/executionController.ts
@@ -1,8 +1,13 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { executionService } from "@/services/executionService";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 type ExecutionIdParams = {
   executionId: string;
@@ -10,7 +15,7 @@ type ExecutionIdParams = {
 
 export const executionController = {
   getExecutionById: async (
-    req: Request<ExecutionIdParams>,
+    req: AuthenticatedRequest<ExecutionIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -31,18 +36,20 @@ export const executionController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const execution = await executionService.getExecutionById(executionId, projectId);
       res.status(200).json(execution);
     } catch (error) {
       const err = error as Error;
-      res.status(404).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 404).json({
         error: err.message,
       });
     }
   },
 
   deleteExecution: async (
-    req: Request<ExecutionIdParams>,
+    req: AuthenticatedRequest<ExecutionIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -63,11 +70,17 @@ export const executionController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       await executionService.deleteExecution(executionId, projectId);
       res.status(204).send();
     } catch (error) {
       const err = error as Error;
-      if (err.message.includes("not found")) {
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: err.message,
+        });
+      } else if (err.message.includes("not found")) {
         res.status(404).json({
           error: err.message,
         });

--- a/src/controllers/issueController.ts
+++ b/src/controllers/issueController.ts
@@ -1,10 +1,14 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { type AuthenticatedRequest } from "@/middleware/authMiddleware";
 import { issueService } from "@/services/issueService";
 import { buildIssueParams } from "@/lib/params-builder";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 import type { CreateIssueParams, UpdateIssueParams } from "@/types";
 
@@ -13,7 +17,7 @@ type IssueIdParams = {
 };
 
 export const issueController = {
-  getAllIssues: async (req: Request, res: Response): Promise<void> => {
+  getAllIssues: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const {
         projectId,
@@ -30,6 +34,8 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const params = buildIssueParams({
         projectId,
         category,
@@ -42,12 +48,12 @@ export const issueController = {
       res.status(200).json(result);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch issues. ${err.message}`,
       });
     }
   },
-  getAllIssuesV2: async (req: Request, res: Response): Promise<void> => {
+  getAllIssuesV2: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const {
         projectId,
@@ -64,6 +70,8 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const params = buildIssueParams({
         projectId,
         category,
@@ -76,13 +84,13 @@ export const issueController = {
       res.status(200).json(result);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch issues. ${err.message}`,
       });
     }
   },
 
-  getAllIssuesWithStats: async (req: Request, res: Response): Promise<void> => {
+  getAllIssuesWithStats: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const {
         projectId,
@@ -100,6 +108,8 @@ export const issueController = {
         });
         return;
       }
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
 
       const params = buildIssueParams({
         projectId,
@@ -115,14 +125,14 @@ export const issueController = {
       res.status(200).json(result);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch issues with statistics. ${err.message}`,
       });
     }
   },
 
   getAllIssuesWithStatsV2: async (
-    req: Request,
+    req: AuthenticatedRequest,
     res: Response,
   ): Promise<void> => {
     try {
@@ -143,6 +153,8 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const params = buildIssueParams({
         projectId,
         category,
@@ -157,14 +169,14 @@ export const issueController = {
       res.status(200).json(result);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch issues with statistics. ${err.message}`,
       });
     }
   },
 
   getIssueById: async (
-    req: Request<IssueIdParams>,
+    req: AuthenticatedRequest<IssueIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -185,6 +197,8 @@ export const issueController = {
         });
         return;
       }
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
 
       const issueRecords = await issueService.getIssueById(issueId, projectId);
       res.status(200).json(issueRecords);
@@ -198,7 +212,7 @@ export const issueController = {
 
   // V2 method with serialized response including user information
   getIssueByIdV2: async (
-    req: Request<IssueIdParams>,
+    req: AuthenticatedRequest<IssueIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -219,6 +233,8 @@ export const issueController = {
         });
         return;
       }
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
 
       const issueRecords = await issueService.getIssueByIdV2(
         issueId,
@@ -233,10 +249,10 @@ export const issueController = {
     }
   },
 
-  createIssue: async (req: Request, res: Response): Promise<void> => {
+  createIssue: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const issueParams: CreateIssueParams = req.body;
-      const user = (req as AuthenticatedRequest).user;
+      const user = req.user;
       if (user) {
         issueParams.createdById = user.id;
         issueParams.updatedById = user.id;
@@ -256,18 +272,20 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, issueParams.projectId);
+
       const issueRecord = await issueService.createIssue(issueParams);
       res.status(201).json(issueRecord);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: err.message,
       });
     }
   },
 
   updateIssue: async (
-    req: Request<IssueIdParams>,
+    req: AuthenticatedRequest<IssueIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -292,18 +310,20 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertIssueAccess(req.user, issueId);
+
       const updatedIssue = await issueService.updateIssue(issueId, updateData);
       res.status(200).json(updatedIssue);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to update issue. ${err.message}`,
       });
     }
   },
 
   deleteIssue: async (
-    req: Request<IssueIdParams>,
+    req: AuthenticatedRequest<IssueIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -325,6 +345,8 @@ export const issueController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const deletedIssue = await issueService.deleteIssue(issueId, projectId);
       res.status(200).json({
         message: "Issue and all associated assumptions deleted successfully",
@@ -334,6 +356,13 @@ export const issueController = {
       const err = error as Error;
 
       // Check if it's a "not found" error
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: err.message,
+        });
+        return;
+      }
+
       if (err.message.includes("not found")) {
         res.status(404).json({
           error: err.message,

--- a/src/controllers/jsonReportController.ts
+++ b/src/controllers/jsonReportController.ts
@@ -13,6 +13,10 @@ import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
 import { dbClient } from "@/prisma/client";
 import getLogger from "@/lib/logger";
 import { dashboardService } from "@/services/dashboardService";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const logger = getLogger("json-report-controller");
 
@@ -173,6 +177,10 @@ export const jsonReportController = {
         .projectId;
       const userId = req.user?.id;
 
+      if (projectId) {
+        await projectAccessService.assertProjectAccess(req.user, projectId);
+      }
+
       const response = await jsonReportController._processRawReportFileCore(
         req.file,
         projectId,
@@ -182,7 +190,7 @@ export const jsonReportController = {
       res.status(201).json(response);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to process raw JSON report file. ${err.message}`,
       });
     }

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -1,9 +1,13 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { projectService } from "@/services/projectService";
 import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 import {
   DEFAULT_PROJECT_CATEGORY_WEIGHTS,
   parseProjectCategoryWeights,
@@ -15,18 +19,20 @@ type ProjectIdParams = {
 };
 
 export const projectController = {
-  async getProjects(_req: Request, res: Response): Promise<void> {
+  async getProjects(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
-      const projects = await projectService.getProjects({});
+      const projects = await projectService.getProjects(
+        projectAccessService.projectFilterForUser(req.user),
+      );
       res.json(projects);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({ error: err.message });
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({ error: err.message });
     }
   },
 
   async getProjectById(
-    req: Request<ProjectIdParams>,
+    req: AuthenticatedRequest<ProjectIdParams>,
     res: Response,
   ): Promise<void> {
     try {
@@ -38,7 +44,10 @@ export const projectController = {
         return;
       }
 
-      const project = await projectService.getProjectById(id);
+      const project = await projectAccessService.assertProjectAccess(
+        req.user,
+        id,
+      );
 
       if (!project) {
         res.status(404).json({ error: "Project not found" });
@@ -48,7 +57,7 @@ export const projectController = {
       res.json(project);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({ error: err.message });
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({ error: err.message });
     }
   },
 
@@ -102,7 +111,7 @@ export const projectController = {
   },
 
   async updateProject(
-    req: Request<ProjectIdParams>,
+    req: AuthenticatedRequest<ProjectIdParams>,
     res: Response,
   ): Promise<void> {
     try {
@@ -156,11 +165,15 @@ export const projectController = {
         }
       }
 
+      await projectAccessService.assertProjectAccess(req.user, id);
+
       const project = await projectService.updateProject(id, updateData);
       res.json(project);
     } catch (error) {
       const err = error as Error;
-      if (err.message.includes("already exists")) {
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({ error: err.message });
+      } else if (err.message.includes("already exists")) {
         res.status(409).json({ error: err.message });
       } else if (err.message.includes("not found")) {
         res.status(404).json({ error: err.message });
@@ -171,7 +184,7 @@ export const projectController = {
   },
 
   async deleteProject(
-    req: Request<ProjectIdParams>,
+    req: AuthenticatedRequest<ProjectIdParams>,
     res: Response,
   ): Promise<void> {
     try {
@@ -183,11 +196,15 @@ export const projectController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, id);
+
       await projectService.deleteProject(id);
       res.status(204).send();
     } catch (error) {
       const err = error as Error;
-      if (err.message.includes("not found")) {
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({ error: err.message });
+      } else if (err.message.includes("not found")) {
         res.status(404).json({ error: err.message });
       } else {
         res.status(500).json({ error: err.message });

--- a/src/controllers/reportController.ts
+++ b/src/controllers/reportController.ts
@@ -1,10 +1,15 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Request, Response } from "express";
+import type { Response } from "express";
 import getLogger from "@/lib/logger";
 import { reportService, ReportGenerationError } from "@/services/reportService";
 import type { PdfExportFilters } from "@/types/dashboard";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const logger = getLogger("report-controller");
 
@@ -23,7 +28,7 @@ function buildFilename(params: PdfExportFilters): string {
 }
 
 export const reportController = {
-  async exportPdf(req: Request, res: Response): Promise<void> {
+  async exportPdf(req: AuthenticatedRequest, res: Response): Promise<void> {
     const params = res.locals.exportParams as PdfExportFilters | undefined;
 
     if (!params) {
@@ -44,6 +49,11 @@ export const reportController = {
     });
 
     try {
+      await projectAccessService.assertProjectReferenceAccess(
+        req.user,
+        params.project,
+      );
+
       const pdf = await reportService.generatePdf(params);
 
       if (timedOut) {
@@ -82,6 +92,11 @@ export const reportController = {
           res.status(500).json({ error: "PDF_BUILD_FAILED" });
           return;
         }
+      }
+
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({ error: error.message });
+        return;
       }
 
       res.status(500).json({ error: "PDF_BUILD_FAILED" });

--- a/src/controllers/resultController.ts
+++ b/src/controllers/resultController.ts
@@ -1,11 +1,15 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { resultService } from "@/services/resultService";
 import type { GetResultsStatsParams } from "@/types";
 import { buildResultParams } from "@/lib/params-builder";
 import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 type AnalysisFeedbackData = {
   analysisFeedbackCategory?: string;
@@ -83,7 +87,7 @@ const buildExportFileName = (
 };
 
 export const resultController = {
-  getResults: async (req: Request, res: Response): Promise<void> => {
+  getResults: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const params = buildResultParams(req.query as Record<string, string>);
 
@@ -95,19 +99,21 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, params.projectId);
+
       const result = await resultService.getResults(params);
 
       res.json(result);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch results. ${err.message}`,
       });
     }
   },
 
   getResultById: async (
-    req: Request<ResultIdParams>,
+    req: AuthenticatedRequest<ResultIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -128,6 +134,8 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const resultRecord = await resultService.getResultById(
         resultId,
         projectId,
@@ -135,13 +143,13 @@ export const resultController = {
       res.status(200).json(resultRecord);
     } catch (error) {
       const err = error as Error;
-      res.status(404).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 404).json({
         error: err.message,
       });
     }
   },
 
-  getResultsStats: async (req: Request, res: Response): Promise<void> => {
+  getResultsStats: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const { projectId, dates } = req.query;
 
@@ -167,19 +175,22 @@ export const resultController = {
         projectId,
         ...(parsedDates && { dates: parsedDates }),
       };
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const stats = await resultService.getResultsStats(params);
 
       res.json(stats);
     } catch (error) {
       const err = error as Error;
-      res.status(500).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 500).json({
         error: `Failed to fetch results stats. ${err.message}`,
       });
     }
   },
 
   updateAnalysis: async (
-    req: Request<ResultIdParams>,
+    req: AuthenticatedRequest<ResultIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -224,6 +235,8 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertResultAccess(req.user, resultId);
+
       const updatedResult = await resultService.updateAnalysis(
         resultId,
         analysisData,
@@ -232,7 +245,7 @@ export const resultController = {
       res.status(200).json(updatedResult);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to update result analysis. ${err.message}`,
       });
     }
@@ -252,6 +265,11 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertResultAccess(
+        req.user,
+        prepared.resultId as string,
+      );
+
       const updatedResult = await resultService.updateAnalysisFeedback(
         prepared.resultId as string,
         prepared.data as AnalysisFeedbackData,
@@ -261,14 +279,14 @@ export const resultController = {
       res.status(200).json(updatedResult);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to update result analysis feedback. ${err.message}`,
       });
     }
   },
 
   deleteResult: async (
-    req: Request<ResultIdParams>,
+    req: AuthenticatedRequest<ResultIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -289,11 +307,17 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       await resultService.deleteResult(resultId, projectId);
       res.status(204).send();
     } catch (error) {
       const err = error as Error;
-      if (err.message.includes("not found")) {
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: err.message,
+        });
+      } else if (err.message.includes("not found")) {
         res.status(404).json({
           error: err.message,
         });
@@ -305,10 +329,15 @@ export const resultController = {
     }
   },
 
-  exportAnalysisJsonl: async (req: Request, res: Response): Promise<void> => {
+  exportAnalysisJsonl: async (
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<void> => {
     try {
-      const { projectId, dateFrom, dateTo } =
-        req.query as Record<string, string>;
+      const { projectId, dateFrom, dateTo } = req.query as Record<
+        string,
+        string
+      >;
 
       if (!projectId) {
         res.status(400).json({
@@ -324,6 +353,8 @@ export const resultController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const { content } = await resultService.exportAnalysisJsonl({
         projectId,
         dateFrom,
@@ -333,15 +364,12 @@ export const resultController = {
       const filename = buildExportFileName(projectId, dateFrom, dateTo);
 
       res.set("Content-Type", "application/jsonl; charset=utf-8");
-      res.set(
-        "Content-Disposition",
-        `attachment; filename="${filename}"`,
-      );
+      res.set("Content-Disposition", `attachment; filename="${filename}"`);
 
       res.status(200).send(content);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to export analysis. ${err.message}`,
       });
     }

--- a/src/controllers/resultErrorController.ts
+++ b/src/controllers/resultErrorController.ts
@@ -1,8 +1,13 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { resultErrorService } from "@/services/resultErrorService";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 interface AssignIssueRequest {
   assumptionId: string; // UUID
@@ -39,7 +44,7 @@ const validateAnalyzeErrorsRequest = (
 
 export const resultErrorController = {
   assignIssue: async (
-    req: Request<ResultErrorIdParams>,
+    req: AuthenticatedRequest<ResultErrorIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -60,6 +65,9 @@ export const resultErrorController = {
         return;
       }
 
+      await projectAccessService.assertResultErrorAccess(req.user, resultErrorId);
+      await projectAccessService.assertAssumptionAccess(req.user, assumptionId);
+
       const updatedRecord = await resultErrorService.assignIssue(
         resultErrorId,
         assumptionId,
@@ -67,14 +75,14 @@ export const resultErrorController = {
       res.status(200).json(updatedRecord);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to assign issue. ${err.message}`,
       });
     }
   },
 
   reviewError: async (
-    req: Request<ResultErrorIdParams>,
+    req: AuthenticatedRequest<ResultErrorIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -87,18 +95,22 @@ export const resultErrorController = {
         return;
       }
 
-      const reviewedRecord =
-        await resultErrorService.reviewError(resultErrorId);
+      await projectAccessService.assertResultErrorAccess(req.user, resultErrorId);
+
+      const reviewedRecord = await resultErrorService.reviewError(resultErrorId);
       res.status(200).json(reviewedRecord);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to review result error. ${err.message}`,
       });
     }
   },
 
-  bulkReview: async (req: Request, res: Response): Promise<void> => {
+  bulkReview: async (
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<void> => {
     try {
       const { errorIds }: BulkReviewRequest = req.body;
 
@@ -109,20 +121,33 @@ export const resultErrorController = {
         return;
       }
 
+      await Promise.all(
+        errorIds.map((errorId) =>
+          projectAccessService.assertResultErrorAccess(req.user, errorId),
+        ),
+      );
+
       const bulkResults = await resultErrorService.bulkReview(errorIds);
       res.status(200).json(bulkResults);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to complete bulk review. ${err.message}`,
       });
     }
   },
 
-  analyzeErrors: async (req: Request, res: Response): Promise<void> => {
+  analyzeErrors: async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
       const { projectId, errorIds } = validateAnalyzeErrorsRequest(
         req.body as AnalyzeErrorsRequest,
+      );
+
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+      await Promise.all(
+        errorIds.map((errorId) =>
+          projectAccessService.assertResultErrorAccess(req.user, errorId),
+        ),
       );
 
       const analysisResult = await resultErrorService.analyzeErrors(
@@ -133,14 +158,14 @@ export const resultErrorController = {
       res.status(200).json(analysisResult);
     } catch (error) {
       const err = error as Error;
-      res.status(400).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 400).json({
         error: `Failed to analyze result errors. ${err.message}`,
       });
     }
   },
 
   getResultErrorById: async (
-    req: Request<ResultErrorIdParams>,
+    req: AuthenticatedRequest<ResultErrorIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -161,6 +186,8 @@ export const resultErrorController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId as string);
+
       const resultError = await resultErrorService.getResultErrorById(
         resultErrorId,
         projectId as string,
@@ -168,7 +195,7 @@ export const resultErrorController = {
       res.status(200).json(resultError);
     } catch (error) {
       const err = error as Error;
-      res.status(404).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 404).json({
         error: err.message,
       });
     }

--- a/src/controllers/specController.ts
+++ b/src/controllers/specController.ts
@@ -1,8 +1,13 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { Request, Response } from "express";
+import { Response } from "express";
 import { specService } from "@/services/specService";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 type SpecIdParams = {
   specId: string;
@@ -10,7 +15,7 @@ type SpecIdParams = {
 
 export const specController = {
   getSpecById: async (
-    req: Request<SpecIdParams>,
+    req: AuthenticatedRequest<SpecIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -31,18 +36,20 @@ export const specController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const spec = await specService.getSpecById(specId, projectId);
       res.status(200).json(spec);
     } catch (error) {
       const err = error as Error;
-      res.status(404).json({
+      res.status(error instanceof ProjectAccessError ? error.statusCode : 404).json({
         error: err.message,
       });
     }
   },
 
   deleteSpec: async (
-    req: Request<SpecIdParams>,
+    req: AuthenticatedRequest<SpecIdParams>,
     res: Response,
   ): Promise<void> => {
     try {
@@ -63,11 +70,17 @@ export const specController = {
         return;
       }
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       await specService.deleteSpec(specId, projectId);
       res.status(204).send();
     } catch (error) {
       const err = error as Error;
-      if (err.message.includes("not found")) {
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: err.message,
+        });
+      } else if (err.message.includes("not found")) {
         res.status(404).json({
           error: err.message,
         });

--- a/src/controllers/uploadApiKeyController.ts
+++ b/src/controllers/uploadApiKeyController.ts
@@ -5,6 +5,10 @@ import type { Response } from "express";
 import { uploadApiKeyService } from "@/services/uploadApiKeyService";
 import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
 import getLogger from "@/lib/logger";
+import {
+  ProjectAccessError,
+  projectAccessService,
+} from "@/services/projectAccessService";
 
 const logger = getLogger("upload-api-key-controller");
 
@@ -40,6 +44,8 @@ export const uploadApiKeyController = {
         `Generating API key for project ${projectId} by user ${userId}`,
       );
 
+      await projectAccessService.assertProjectAccess(req.user, projectId);
+
       const apiKeyData = await uploadApiKeyService.generateApiKey(
         projectId,
         userId,
@@ -60,6 +66,13 @@ export const uploadApiKeyController = {
       res.json(response);
     } catch (error) {
       logger.error("Error generating API key:", error);
+      if (error instanceof ProjectAccessError) {
+        res.status(error.statusCode).json({
+          error: error.message,
+        });
+        return;
+      }
+
       res.status(500).json({
         error: "Failed to generate API key",
         details: error instanceof Error ? error.message : "Unknown error",

--- a/src/services/projectAccessService.ts
+++ b/src/services/projectAccessService.ts
@@ -1,0 +1,177 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { dbClient } from "@/prisma/client";
+import { projectModel } from "@/models/projectModel";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+
+type AuthenticatedUser = NonNullable<AuthenticatedRequest["user"]>;
+
+export class ProjectAccessError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "ProjectAccessError";
+  }
+}
+
+function ensureUser(user: AuthenticatedRequest["user"]): AuthenticatedUser {
+  if (!user) {
+    throw new ProjectAccessError("User is not authenticated", 401);
+  }
+
+  return user;
+}
+
+function canAccessProject(user: AuthenticatedUser, ownerId: string): boolean {
+  return user.role === "admin" || ownerId === user.id;
+}
+
+function toAccessDenied(): ProjectAccessError {
+  return new ProjectAccessError("Project access denied", 403);
+}
+
+export const projectAccessService = {
+  projectFilterForUser(user: AuthenticatedRequest["user"]) {
+    const currentUser = ensureUser(user);
+
+    return currentUser.role === "admin" ? {} : { ownerId: currentUser.id };
+  },
+
+  async assertProjectAccess(
+    user: AuthenticatedRequest["user"],
+    projectId: string,
+  ) {
+    const currentUser = ensureUser(user);
+    const project = await projectModel.findById(projectId);
+
+    if (!project) {
+      throw new ProjectAccessError("Project not found", 404);
+    }
+
+    if (!canAccessProject(currentUser, project.ownerId)) {
+      throw toAccessDenied();
+    }
+
+    return project;
+  },
+
+  async assertProjectReferenceAccess(
+    user: AuthenticatedRequest["user"],
+    projectReference: string,
+  ) {
+    const currentUser = ensureUser(user);
+    const project =
+      (await projectModel.findById(projectReference)) ??
+      (await projectModel.findByName(projectReference));
+
+    if (!project) {
+      throw new ProjectAccessError("Project not found", 404);
+    }
+
+    if (!canAccessProject(currentUser, project.ownerId)) {
+      throw toAccessDenied();
+    }
+
+    return project;
+  },
+
+  async assertIssueAccess(
+    user: AuthenticatedRequest["user"],
+    issueId: string,
+  ): Promise<void> {
+    const issue = await dbClient.issue.findUnique({
+      where: { id: issueId },
+      select: { projectId: true },
+    });
+
+    if (!issue) {
+      throw new ProjectAccessError("Issue not found", 404);
+    }
+
+    await this.assertProjectAccess(user, issue.projectId);
+  },
+
+  async assertResultErrorAccess(
+    user: AuthenticatedRequest["user"],
+    resultErrorId: string,
+  ): Promise<void> {
+    const resultError = await dbClient.resultError.findUnique({
+      where: { id: resultErrorId },
+      select: {
+        result: {
+          select: {
+            spec: { select: { projectId: true } },
+            execution: { select: { projectId: true } },
+          },
+        },
+      },
+    });
+
+    const projectId =
+      resultError?.result?.spec.projectId ??
+      resultError?.result?.execution.projectId;
+
+    if (!projectId) {
+      throw new ProjectAccessError("Result error not found", 404);
+    }
+
+    await this.assertProjectAccess(user, projectId);
+  },
+
+  async assertResultAccess(
+    user: AuthenticatedRequest["user"],
+    resultId: string,
+  ): Promise<void> {
+    const result = await dbClient.result.findUnique({
+      where: { id: resultId },
+      select: {
+        spec: { select: { projectId: true } },
+        execution: { select: { projectId: true } },
+      },
+    });
+
+    const projectId = result?.spec.projectId ?? result?.execution.projectId;
+
+    if (!projectId) {
+      throw new ProjectAccessError("Result not found", 404);
+    }
+
+    await this.assertProjectAccess(user, projectId);
+  },
+
+  async assertAssumptionAccess(
+    user: AuthenticatedRequest["user"],
+    assumptionId: string,
+  ): Promise<void> {
+    const assumption = await dbClient.assumption.findUnique({
+      where: { id: assumptionId },
+      select: {
+        issue: { select: { projectId: true } },
+        resultError: {
+          select: {
+            result: {
+              select: {
+                spec: { select: { projectId: true } },
+                execution: { select: { projectId: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const projectId =
+      assumption?.issue.projectId ??
+      assumption?.resultError?.result?.spec.projectId ??
+      assumption?.resultError?.result?.execution.projectId;
+
+    if (!projectId) {
+      throw new ProjectAccessError("Assumption not found", 404);
+    }
+
+    await this.assertProjectAccess(user, projectId);
+  },
+};

--- a/src/services/uploadApiKeyService.ts
+++ b/src/services/uploadApiKeyService.ts
@@ -182,6 +182,13 @@ export const uploadApiKeyService = {
       throw new Error("API key has been revoked or does not exist");
     }
 
+    if (
+      keyRecord.projectId !== validated.projectId ||
+      keyRecord.ownerId !== validated.ownerId
+    ) {
+      throw new Error("API key payload does not match stored key record");
+    }
+
     return {
       projectId: validated.projectId,
       ownerId: validated.ownerId,


### PR DESCRIPTION
## Summary

This PR adds centralized project-level authorization checks for project-scoped resources.

The API already authenticates users, but project-scoped operations should also verify that the authenticated user can access the resolved project before reading or modifying related data.

## Changes

- Add `projectAccessService` for centralized project access checks.
- Allow project owners to access their own projects.
- Allow admins to access all projects.
- Deny access for other member users.
- Apply project access checks to:
  - projects
  - results
  - executions
  - specs
  - result errors
  - issues
  - assumptions
  - dashboard
  - PDF export
  - JSON/CTRF upload
  - upload API key generation
- Validate upload API key payload values against the stored database record.

## Tests

- Added regression tests for project access decisions.
- Added regression test for forged upload API key payload mismatch.
- Updated issue auth flow test for project ownership checks.

Validated locally:

```text
npm run type-check
npx jest --config jest.config.ts __tests__/services/projectAccessService.test.ts __tests__/services/uploadApiKeyService.security.test.ts __tests__/routes/issue.test.ts --runInBand
npx eslint <changed files>
```

Note: full `npm run lint` currently reports existing lint errors in `.agents/skills/cartodex/scripts/scan-codebase.mjs`, unrelated to this PR.