### PR TITLE
fix: add limits for AI-backed endpoints

### DIFF
--- a/__tests__/controllers/resultErrorController.test.ts
+++ b/__tests__/controllers/resultErrorController.test.ts
@@ -5,6 +5,7 @@ import "@/test-utils/testEnv";
 import { jest } from "@jest/globals";
 import { executeController } from "@/test-utils/httpMocks";
 import { resultErrorController } from "@/controllers/resultErrorController";
+import { MAX_ANALYZE_ERROR_IDS } from "@/config/aiLimits";
 import { resultErrorService } from "@/services/resultErrorService";
 
 describe("resultErrorController.analyzeErrors", () => {
@@ -62,6 +63,27 @@ describe("resultErrorController.analyzeErrors", () => {
       updatedResultIds: ["res-1"],
       skippedErrorIds: [],
       totalErrors: 1,
+    });
+  });
+
+  it("returns 400 when errorIds exceeds the analysis batch limit", async () => {
+    const analyzeErrorsSpy = jest.spyOn(resultErrorService, "analyzeErrors");
+
+    const res = await executeController(resultErrorController.analyzeErrors, {
+      method: "POST",
+      body: {
+        projectId: "project-1",
+        errorIds: Array.from(
+          { length: MAX_ANALYZE_ERROR_IDS + 1 },
+          (_, index) => `err-${index}`,
+        ),
+      },
+    });
+
+    expect(analyzeErrorsSpy).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: `Failed to analyze result errors. Error IDs array cannot contain more than ${MAX_ANALYZE_ERROR_IDS} items`,
     });
   });
 

--- a/__tests__/services/resultErrorService.test.ts
+++ b/__tests__/services/resultErrorService.test.ts
@@ -4,6 +4,7 @@
 import "@/test-utils/testEnv";
 import { jest } from "@jest/globals";
 import { resultErrorService } from "@/services/resultErrorService";
+import { MAX_ANALYZE_ERROR_IDS } from "@/config/aiLimits";
 import { resultErrorModel } from "@/models/resultErrorModel";
 import { testAnalysisService } from "@/services/testAnalysisService";
 import { dashboardService } from "@/services/dashboardService";
@@ -46,6 +47,20 @@ describe("resultErrorService.analyzeErrors", () => {
     await expect(
       resultErrorService.analyzeErrors("project-1", [""]),
     ).rejects.toThrow("Error IDs must be non-empty strings");
+  });
+
+  it("throws when errorIds exceeds the analysis batch limit", async () => {
+    await expect(
+      resultErrorService.analyzeErrors(
+        "project-1",
+        Array.from(
+          { length: MAX_ANALYZE_ERROR_IDS + 1 },
+          (_, index) => `err-${index}`,
+        ),
+      ),
+    ).rejects.toThrow(
+      `Error IDs array cannot contain more than ${MAX_ANALYZE_ERROR_IDS} items`,
+    );
   });
 
   it("analyzes deduped results and updates stats", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cors": "2.8.5",
         "dotenv": "16.6.1",
         "express": "5.2.1",
+        "express-rate-limit": "^8.6.0",
         "express-session": "1.18.2",
         "fast-levenshtein": "3.0.0",
         "helmet": "8.1.0",
@@ -5576,11 +5577,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cors": "2.8.5",
     "dotenv": "16.6.1",
     "express": "5.2.1",
+    "express-rate-limit": "^8.6.0",
     "express-session": "1.18.2",
     "fast-levenshtein": "3.0.0",
     "helmet": "8.1.0",

--- a/src/config/aiLimits.ts
+++ b/src/config/aiLimits.ts
@@ -1,0 +1,4 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export const MAX_ANALYZE_ERROR_IDS = 50;

--- a/src/controllers/resultErrorController.ts
+++ b/src/controllers/resultErrorController.ts
@@ -3,6 +3,7 @@
 
 import { Request, Response } from "express";
 import { resultErrorService } from "@/services/resultErrorService";
+import { MAX_ANALYZE_ERROR_IDS } from "@/config/aiLimits";
 
 interface AssignIssueRequest {
   assumptionId: string; // UUID
@@ -32,6 +33,12 @@ const validateAnalyzeErrorsRequest = (
 
   if (!errorIds || !Array.isArray(errorIds) || errorIds.length === 0) {
     throw new Error("Error IDs array is required and must not be empty");
+  }
+
+  if (errorIds.length > MAX_ANALYZE_ERROR_IDS) {
+    throw new Error(
+      `Error IDs array cannot contain more than ${MAX_ANALYZE_ERROR_IDS} items`,
+    );
   }
 
   return { projectId, errorIds };

--- a/src/middleware/aiRateLimit.ts
+++ b/src/middleware/aiRateLimit.ts
@@ -28,3 +28,22 @@ export const aiRateLimit = rateLimit({
       "Too many AI requests. Please wait before requesting another AI analysis.",
   },
 });
+
+export const aiInsightsRateLimit = rateLimit({
+  windowMs: AI_RATE_LIMIT_WINDOW_MS,
+  limit: AI_RATE_LIMIT_MAX_REQUESTS,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  keyGenerator: aiRateLimitKey,
+  skip: (req) =>
+    !(
+      req.body &&
+      typeof req.body === "object" &&
+      "includeAiInsights" in req.body &&
+      req.body.includeAiInsights === true
+    ),
+  message: {
+    error:
+      "Too many AI insight requests. Please wait before requesting another AI insight.",
+  },
+});

--- a/src/middleware/aiRateLimit.ts
+++ b/src/middleware/aiRateLimit.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { ipKeyGenerator, rateLimit } from "express-rate-limit";
+import type { Request } from "express";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+
+const AI_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const AI_RATE_LIMIT_MAX_REQUESTS = 20;
+
+const aiRateLimitKey = (req: Request): string => {
+  const userId = (req as AuthenticatedRequest).user?.id;
+  if (userId) {
+    return `user:${userId}`;
+  }
+
+  return req.ip ? `ip:${ipKeyGenerator(req.ip)}` : "unknown-client";
+};
+
+export const aiRateLimit = rateLimit({
+  windowMs: AI_RATE_LIMIT_WINDOW_MS,
+  limit: AI_RATE_LIMIT_MAX_REQUESTS,
+  standardHeaders: "draft-8",
+  legacyHeaders: false,
+  keyGenerator: aiRateLimitKey,
+  message: {
+    error:
+      "Too many AI requests. Please wait before requesting another AI analysis.",
+  },
+});

--- a/src/routes/error-formatter.ts
+++ b/src/routes/error-formatter.ts
@@ -4,17 +4,20 @@
 import { Router } from "express";
 import { errorFormatterController } from "@/controllers/errorFormatterController";
 import { authMiddleware } from "@/middleware/authMiddleware";
+import { aiRateLimit } from "@/middleware/aiRateLimit";
 
 const router = Router();
 
 router.post(
   "/v2/error-formatter",
   authMiddleware,
+  aiRateLimit,
   errorFormatterController.formatError,
 );
 router.post(
   "/v2/error-formatter/result",
   authMiddleware,
+  aiRateLimit,
   errorFormatterController.suggestFromResult,
 );
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -3,6 +3,7 @@
 
 import { Router } from "express";
 import { authMiddleware } from "@/middleware/authMiddleware";
+import { aiInsightsRateLimit } from "@/middleware/aiRateLimit";
 import { validatePdfExport } from "@/middleware/validatePdfExport";
 import { reportController } from "@/controllers/reportController";
 
@@ -11,6 +12,7 @@ const router = Router();
 router.post(
   "/v2/reports/pdf-export",
   authMiddleware,
+  aiInsightsRateLimit,
   validatePdfExport,
   reportController.exportPdf,
 );

--- a/src/routes/result-errors.ts
+++ b/src/routes/result-errors.ts
@@ -4,6 +4,7 @@
 import { Router } from "express";
 import { resultErrorController } from "@/controllers/resultErrorController";
 import { authMiddleware } from "@/middleware/authMiddleware";
+import { aiRateLimit } from "@/middleware/aiRateLimit";
 
 const router = Router();
 
@@ -25,6 +26,7 @@ router.patch(
 router.post(
   "/v2/result-errors/analyze",
   authMiddleware,
+  aiRateLimit,
   resultErrorController.analyzeErrors,
 );
 router.get(

--- a/src/services/resultErrorService.ts
+++ b/src/services/resultErrorService.ts
@@ -12,6 +12,7 @@ import type {
   ResultErrorWithRelations,
   StructuredResultError,
 } from "@/types";
+import { MAX_ANALYZE_ERROR_IDS } from "@/config/aiLimits";
 
 const logger = getLogger("result-error-service");
 
@@ -42,6 +43,12 @@ const validateAnalyzeErrorsParams = (
 
   if (!errorIds || !Array.isArray(errorIds) || errorIds.length === 0) {
     throw new Error("Error IDs array is required and must not be empty");
+  }
+
+  if (errorIds.length > MAX_ANALYZE_ERROR_IDS) {
+    throw new Error(
+      `Error IDs array cannot contain more than ${MAX_ANALYZE_ERROR_IDS} items`,
+    );
   }
 
   if (errorIds.some((id) => typeof id !== "string" || id.length === 0)) {


### PR DESCRIPTION
## Summary

This PR adds initial abuse-protection guardrails for AI-backed endpoints.

The affected endpoints can trigger OpenAI/LangChain calls, so they should have stricter request controls than ordinary read/write API endpoints.

## Changes

- Add `express-rate-limit`.
- Add shared `aiRateLimit` middleware.
- Apply AI rate limiting to:
  - `POST /api/v2/error-formatter`
  - `POST /api/v2/error-formatter/result`
  - `POST /api/v2/result-errors/analyze`
- Add `MAX_ANALYZE_ERROR_IDS = 50`.
- Reject oversized `/result-errors/analyze` batches before calling the analysis service.
- Add controller/service regression tests for the batch limit.

## Tests

Validated locally:

```text
npm run type-check
npx jest --config jest.config.ts __tests__/controllers/resultErrorController.test.ts __tests__/services/resultErrorService.test.ts --runInBand
npx eslint src/middleware/aiRateLimit.ts src/routes/error-formatter.ts src/routes/result-errors.ts src/controllers/resultErrorController.ts src/services/resultErrorService.ts src/config/aiLimits.ts __tests__/controllers/resultErrorController.test.ts __tests__/services/resultErrorService.test.ts