### PR TITLE
Add Markdown test scenario API

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@
 url = "https://api.githubcopilot.com/mcp/"
 bearer_token_env_var = "GITHUB_PAT_TOKEN"
 enabled = true
-required = true
+required = false
 default_tools_approval_mode = "auto"
 http_headers = { "X-MCP-Tools" = "get_me,get_file_contents,list_pull_requests,pull_request_read,search_pull_requests,issue_write,create_pull_request,update_pull_request,add_issue_comment,add_reply_to_pull_request_comment,pull_request_review_write", "X-MCP-Lockdown" = "true" }
 enabled_tools = [

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,20 @@
-[features]
-multi_agent = true
-
-[agents]
-max_threads = 6
-max_depth = 1
+[mcp_servers.github_tp]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_PAT_TOKEN"
+enabled = true
+required = true
+default_tools_approval_mode = "auto"
+http_headers = { "X-MCP-Tools" = "get_me,get_file_contents,list_pull_requests,pull_request_read,search_pull_requests,issue_write,create_pull_request,update_pull_request,add_issue_comment,add_reply_to_pull_request_comment,pull_request_review_write", "X-MCP-Lockdown" = "true" }
+enabled_tools = [
+  "get_me",
+  "get_file_contents",
+  "list_pull_requests",
+  "pull_request_read",
+  "search_pull_requests",
+  "issue_write",
+  "create_pull_request",
+  "update_pull_request",
+  "add_issue_comment",
+  "add_reply_to_pull_request_comment",
+  "pull_request_review_write",
+]

--- a/__tests__/controllers/testScenarioController.test.ts
+++ b/__tests__/controllers/testScenarioController.test.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+import {
+  executeController,
+} from "@/test-utils/httpMocks";
+
+const createScenarioMock = jest.fn<() => Promise<TestScenario>>();
+const listScenariosMock = jest.fn<
+  () => Promise<{
+    scenarios: TestScenario[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>
+>();
+const getScenarioByIdMock = jest.fn<() => Promise<TestScenario>>();
+const deleteScenarioMock = jest.fn<() => Promise<void>>();
+
+jest.mock("@/services/testScenarioService", () => ({
+  testScenarioService: {
+    createScenario: createScenarioMock,
+    listScenarios: listScenariosMock,
+    getScenarioById: getScenarioByIdMock,
+    deleteScenario: deleteScenarioMock,
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const scenario: TestScenario = {
+  id: scenarioId,
+  projectId,
+  createdById: "33333333-3333-3333-3333-333333333333",
+  title: "Scenario",
+  contentMd: "# Exact\n\n  Markdown ✓\n",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+const authenticatedUser = {
+  id: scenario.createdById,
+  name: "Scenario Creator",
+  email: "creator@example.com",
+  status: "active",
+  role: "member",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+} as const;
+
+describe("testScenarioController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createScenarioMock.mockResolvedValue(scenario);
+    listScenariosMock.mockResolvedValue({
+      scenarios: [scenario],
+      total: 1,
+      page: 1,
+      limit: 30,
+      totalPages: 1,
+    });
+    getScenarioByIdMock.mockResolvedValue(scenario);
+    deleteScenarioMock.mockResolvedValue(undefined);
+  });
+
+  it("creates a scenario with a 201 response and preserves the response body", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: {
+        projectId,
+        title: "  Scenario  ",
+        contentMd: scenario.contentMd,
+        createdById: "99999999-9999-9999-9999-999999999999",
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toBe(scenario);
+    expect(createScenarioMock).toHaveBeenCalledWith({
+      projectId,
+      title: "Scenario",
+      contentMd: scenario.contentMd,
+      createdById: authenticatedUser.id,
+    });
+  });
+
+  it("requires an authenticated user before creating a scenario", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(createScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed input with 400 without calling the service", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: "not-a-uuid", title: " ", contentMd: "" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual(expect.objectContaining({ error: expect.any(String) }));
+    expect(createScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("maps project not-found and unexpected create errors", async () => {
+    createScenarioMock.mockRejectedValueOnce(
+      new TestScenarioNotFoundError("Project not found"),
+    );
+    const notFound = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+    expect(notFound.statusCode).toBe(404);
+
+    createScenarioMock.mockRejectedValueOnce(new Error("database unavailable"));
+    const failed = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+    expect(failed.statusCode).toBe(500);
+  });
+
+  it("returns the stable default list envelope", async () => {
+    const response = await executeController(testScenarioController.list, {
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      scenarios: [scenario],
+      page: 1,
+      limit: 30,
+    }));
+    expect(listScenariosMock).toHaveBeenCalledWith({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("rejects invalid pagination with 400", async () => {
+    const response = await executeController(testScenarioController.list, {
+      query: { projectId, page: "0", limit: "101" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(listScenariosMock).not.toHaveBeenCalled();
+  });
+
+  it("returns exact Markdown detail data and maps missing records to 404", async () => {
+    const response = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(response.statusCode).toBe(200);
+    expect((response.body as TestScenario).contentMd).toBe(scenario.contentMd);
+
+    getScenarioByIdMock.mockRejectedValueOnce(
+      new TestScenarioNotFoundError("Scenario not found"),
+    );
+    const missing = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("returns an empty 204 deletion response", async () => {
+    const response = await executeController(testScenarioController.delete, {
+      method: "DELETE",
+      params: { scenarioId },
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBeUndefined();
+    expect(deleteScenarioMock).toHaveBeenCalledWith(scenarioId, projectId);
+  });
+});

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateOpenAPISpec } from "@/lib/openapi";
+
+describe("test-scenario OpenAPI contract", () => {
+  it("registers all four authenticated operations under the Test Scenarios tag", () => {
+    const spec = generateOpenAPISpec();
+    const paths = spec.paths ?? {};
+    const list = paths["/api/v2/test-scenarios"]?.get;
+    const create = paths["/api/v2/test-scenarios"]?.post;
+    const detail = paths["/api/v2/test-scenarios/{scenarioId}"]?.get;
+    const remove = paths["/api/v2/test-scenarios/{scenarioId}"]?.delete;
+
+    expect(list).toBeDefined();
+    expect(create).toBeDefined();
+    expect(detail).toBeDefined();
+    expect(remove).toBeDefined();
+    expect(spec.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Test Scenarios" }),
+      ]),
+    );
+
+    for (const operation of [list, create, detail, remove]) {
+      expect(operation?.tags).toContain("Test Scenarios");
+      expect(operation?.security).toEqual([{ BearerAuth: [] }]);
+      expect(operation?.responses?.["400"]).toBeDefined();
+      expect(operation?.responses?.["401"]).toBeDefined();
+    }
+    expect(detail?.responses?.["404"]).toBeDefined();
+    expect(remove?.responses?.["404"]).toBeDefined();
+    expect(create?.responses?.["404"]).toBeDefined();
+    expect(list?.responses?.["500"]).toBeDefined();
+  });
+
+  it("documents the exact resource and pagination envelope", () => {
+    const spec = generateOpenAPISpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    expect(schemas.TestScenario).toBeDefined();
+    expect(schemas.CreateTestScenarioRequest).toBeDefined();
+    expect(schemas.TestScenarioListResponse).toBeDefined();
+    expect(schemas.TestScenarioListQuery).toBeDefined();
+
+    const scenarioSchema = schemas.TestScenario as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+    const createSchema = schemas.CreateTestScenarioRequest as {
+      properties?: Record<string, unknown>;
+    };
+    expect(scenarioSchema.required).toContain("createdById");
+    expect(scenarioSchema.properties?.createdById).toBeDefined();
+    expect(createSchema.properties?.createdById).toBeUndefined();
+
+    const listResponse = schemas.TestScenarioListResponse as {
+      properties?: Record<string, unknown>;
+    };
+    expect(Object.keys(listResponse.properties ?? {})).toEqual([
+      "scenarios",
+      "total",
+      "page",
+      "limit",
+      "totalPages",
+    ]);
+
+    const listQuery = schemas.TestScenarioListQuery as {
+      properties?: Record<string, { maximum?: number; minimum?: number }>;
+    };
+    expect(listQuery.properties?.limit?.minimum).toBe(1);
+    expect(listQuery.properties?.limit?.maximum).toBe(100);
+  });
+
+  it("documents 201 creation and empty 204 deletion", () => {
+    const spec = generateOpenAPISpec();
+
+    expect(
+      spec.paths?.["/api/v2/test-scenarios"]?.post?.responses?.["201"],
+    ).toBeDefined();
+    expect(
+      spec.paths?.["/api/v2/test-scenarios/{scenarioId}"]?.delete?.responses?.[
+        "204"
+      ],
+    ).toEqual(expect.objectContaining({ description: "Test scenario deleted" }));
+  });
+});

--- a/__tests__/models/projectModel.test.ts
+++ b/__tests__/models/projectModel.test.ts
@@ -63,6 +63,9 @@ describe("projectModel", () => {
         dailyExecutionMetric: {
           deleteMany: mockResolved({ count: 1 }),
         },
+        testScenario: {
+          deleteMany: mockResolved({ count: 1 }),
+        },
         uploadApiKey: {
           deleteMany: mockResolved({ count: 0 }),
         },
@@ -82,22 +85,30 @@ describe("projectModel", () => {
       expect(mockTxClient.dailyExecutionMetric.deleteMany).toHaveBeenCalledWith({
         where: { projectId },
       });
+      expect(mockTxClient.testScenario.deleteMany).toHaveBeenCalledWith({
+        where: { projectId },
+      });
       const dailyMetricsDeleteOrder =
         mockTxClient.dailyExecutionMetric.deleteMany.mock
           .invocationCallOrder[0];
+      const scenarioDeleteOrder =
+        mockTxClient.testScenario.deleteMany.mock.invocationCallOrder[0];
       const projectDeleteOrder =
         mockTxClient.project.delete.mock.invocationCallOrder[0];
 
       expect(dailyMetricsDeleteOrder).toEqual(expect.any(Number));
+      expect(scenarioDeleteOrder).toEqual(expect.any(Number));
       expect(projectDeleteOrder).toEqual(expect.any(Number));
 
       if (
         dailyMetricsDeleteOrder === undefined ||
+        scenarioDeleteOrder === undefined ||
         projectDeleteOrder === undefined
       ) {
         throw new Error("Expected delete calls to be recorded");
       }
 
+      expect(scenarioDeleteOrder).toBeLessThan(projectDeleteOrder);
       expect(dailyMetricsDeleteOrder).toBeLessThan(projectDeleteOrder);
       expect(mockTxClient.project.delete).toHaveBeenCalledWith({
         where: { id: projectId },

--- a/__tests__/models/testScenarioModel.test.ts
+++ b/__tests__/models/testScenarioModel.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+
+const createMock = jest.fn<() => Promise<TestScenario>>();
+const findManyMock = jest.fn<() => Promise<TestScenario[]>>();
+const countMock = jest.fn<() => Promise<number>>();
+const findFirstMock = jest.fn<() => Promise<TestScenario | null>>();
+const deleteManyMock = jest.fn<() => Promise<{ count: number }>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    testScenario: {
+      create: createMock,
+      findMany: findManyMock,
+      count: countMock,
+      findFirst: findFirstMock,
+      deleteMany: deleteManyMock,
+    },
+  },
+}));
+
+import { testScenarioModel } from "@/models/testScenarioModel";
+
+const scenario: TestScenario = {
+  id: "11111111-1111-1111-1111-111111111111",
+  projectId: "22222222-2222-2222-2222-222222222222",
+  createdById: "33333333-3333-3333-3333-333333333333",
+  title: "Login",
+  contentMd: "# Login",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("testScenarioModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createMock.mockResolvedValue(scenario);
+    findManyMock.mockResolvedValue([scenario]);
+    countMock.mockResolvedValue(1);
+    findFirstMock.mockResolvedValue(scenario);
+    deleteManyMock.mockResolvedValue({ count: 1 });
+  });
+
+  it("creates only the authored scenario fields", async () => {
+    await testScenarioModel.create({
+      projectId: scenario.projectId,
+      title: scenario.title,
+      contentMd: scenario.contentMd,
+      createdById: scenario.createdById,
+    });
+
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        projectId: scenario.projectId,
+        title: scenario.title,
+        contentMd: scenario.contentMd,
+        createdById: scenario.createdById,
+      },
+    });
+  });
+
+  it("lists by project with deterministic ordering and offset pagination", async () => {
+    await testScenarioModel.findMany(scenario.projectId, 3, 10);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+      skip: 20,
+      take: 10,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+  });
+
+  it("uses the same project predicate for list and count", async () => {
+    await testScenarioModel.findMany(scenario.projectId);
+    await testScenarioModel.count(scenario.projectId);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+      skip: 0,
+      take: 30,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+    expect(countMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+    });
+  });
+
+  it("looks up by the composite scenario and project identity", async () => {
+    await testScenarioModel.findById(scenario.id, scenario.projectId);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: scenario.id, projectId: scenario.projectId },
+    });
+  });
+
+  it("deletes only the composite identity and returns the affected count", async () => {
+    const deletedCount = await testScenarioModel.delete(
+      scenario.id,
+      scenario.projectId,
+    );
+
+    expect(deletedCount).toBe(1);
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { id: scenario.id, projectId: scenario.projectId },
+    });
+  });
+});

--- a/__tests__/prisma/testScenarioMigration.test.ts
+++ b/__tests__/prisma/testScenarioMigration.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+describe("test-scenario persistence contract", () => {
+  const schema = readFileSync(
+    path.join(process.cwd(), "prisma/schema.prisma"),
+    "utf8",
+  );
+  const migration = readFileSync(
+    path.join(
+      process.cwd(),
+      "prisma/migrations/20260824120000_add_test_scenarios/migration.sql",
+    ),
+    "utf8",
+  );
+
+  it("defines a project-owned Markdown record with creator and timestamp fields", () => {
+    expect(schema).toMatch(
+      /model TestScenario \{[\s\S]*id\s+String\s+@id\s+@default\(uuid\(\)\)\s+@db\.Uuid[\s\S]*contentMd\s+String\s+@db\.Text[\s\S]*projectId\s+String\s+@db\.Uuid/,
+    );
+    expect(schema).toContain("testScenarios TestScenario[]");
+    expect(schema).toContain(
+      'testScenariosCreated TestScenario[] @relation("TestScenarioCreatedBy")',
+    );
+    expect(schema).toContain(
+      'createdBy User    @relation("TestScenarioCreatedBy"',
+    );
+  });
+
+  it("creates only the independent scenario table and project foreign key", () => {
+    expect(migration).toContain('CREATE TABLE "TestScenario"');
+    expect(migration).toContain('"contentMd" TEXT NOT NULL');
+    expect(migration).toContain('"createdById" UUID NOT NULL');
+    expect(migration).toContain('"TestScenario_projectId_idx"');
+    expect(migration).toContain('"TestScenario_projectId_createdAt_idx"');
+    expect(migration).toContain('"TestScenario_projectId_fkey"');
+    expect(migration).toContain('"TestScenario_createdById_idx"');
+    expect(migration).toContain('"TestScenario_createdById_fkey"');
+    expect(migration).not.toContain('"Spec"');
+    expect(migration).not.toContain('"Execution"');
+    expect(migration).not.toContain('"Issue"');
+  });
+});

--- a/__tests__/routes/test-scenarios.test.ts
+++ b/__tests__/routes/test-scenarios.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { jest } from "@jest/globals";
+
+const authMiddlewareMock = jest.fn();
+const controllerMocks = {
+  create: jest.fn(),
+  list: jest.fn(),
+  getById: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock("@/middleware/authMiddleware", () => ({
+  authMiddleware: authMiddlewareMock,
+}));
+
+jest.mock("@/controllers/testScenarioController", () => ({
+  testScenarioController: controllerMocks,
+}));
+
+import router from "@/routes/test-scenarios";
+import { authMiddleware } from "@/middleware/authMiddleware";
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+}
+
+const routeLayers = (): RouteLayer[] =>
+  (router as unknown as { stack: RouteLayer[] }).stack;
+
+describe("test-scenario routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers exactly create, list, detail, and delete operations", () => {
+    const routes = routeLayers()
+      .filter((layer) => layer.route)
+      .map((layer) => {
+        const route = layer.route;
+        if (!route) throw new Error("Route metadata is missing");
+        return `${Object.keys(route.methods)[0]} ${route.path}`;
+      });
+
+    expect(routes).toEqual([
+      "post /v2/test-scenarios",
+      "get /v2/test-scenarios",
+      "get /v2/test-scenarios/:scenarioId",
+      "delete /v2/test-scenarios/:scenarioId",
+    ]);
+    expect(routes.some((route) => route.startsWith("patch "))).toBe(false);
+    expect(routes.some((route) => route.startsWith("put "))).toBe(false);
+  });
+
+  it("puts JWT authentication before every scenario controller", () => {
+    for (const layer of routeLayers()) {
+      const route = layer.route;
+      if (!route) continue;
+
+      expect(route.stack.some((entry) => entry.handle === authMiddleware)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("mounts the router in the central API router", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "src/routes/index.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import testScenarios from "@/routes/test-scenarios"');
+    expect(source).toContain("router.use(testScenarios)");
+  });
+
+  it("does not introduce MCP operations", () => {
+    expect(controllerMocks).not.toHaveProperty("mcp");
+  });
+});

--- a/__tests__/services/testScenarioService.test.ts
+++ b/__tests__/services/testScenarioService.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+
+const mockProjectExists = jest.fn<() => Promise<boolean>>();
+const mockCreate = jest.fn<() => Promise<TestScenario>>();
+const mockFindMany = jest.fn<() => Promise<TestScenario[]>>();
+const mockCount = jest.fn<() => Promise<number>>();
+const mockFindById = jest.fn<() => Promise<TestScenario | null>>();
+const mockDelete = jest.fn<() => Promise<number>>();
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: mockProjectExists,
+  },
+}));
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    create: mockCreate,
+    findMany: mockFindMany,
+    count: mockCount,
+    findById: mockFindById,
+    delete: mockDelete,
+  },
+}));
+
+import { testScenarioService } from "@/services/testScenarioService";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+} from "@/types/testScenarios";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const otherProjectId = "22222222-2222-2222-2222-222222222222";
+const scenario: TestScenario = {
+  id: "33333333-3333-3333-3333-333333333333",
+  projectId,
+  createdById: "44444444-4444-4444-4444-444444444444",
+  title: "Login",
+  contentMd: "# Login\n\n```ts\n  const value = '✓';\n```\n",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("testScenarioService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProjectExists.mockResolvedValue(true);
+    mockCreate.mockResolvedValue(scenario);
+    mockFindMany.mockResolvedValue([scenario]);
+    mockCount.mockResolvedValue(1);
+    mockFindById.mockResolvedValue(scenario);
+    mockDelete.mockResolvedValue(1);
+  });
+
+  it("trims titles and preserves Markdown exactly", async () => {
+    const contentMd = "# Heading\n\n  indented ✓\n";
+
+    const result = await testScenarioService.createScenario({
+      projectId,
+      title: "  Scenario title  ",
+      contentMd,
+      createdById: scenario.createdById,
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      projectId,
+      title: "Scenario title",
+      contentMd,
+      createdById: scenario.createdById,
+    });
+    expect(result).toBe(scenario);
+  });
+
+  it("rejects creation for an unknown project before persistence", async () => {
+    mockProjectExists.mockResolvedValue(false);
+
+    await expect(
+      testScenarioService.createScenario({
+      projectId: otherProjectId,
+      title: "Scenario",
+      contentMd: "content",
+      createdById: scenario.createdById,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns stable pagination metadata and forwards page offsets", async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(61);
+
+    const result = await testScenarioService.listScenarios({
+      projectId,
+      page: 3,
+      limit: 30,
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith(projectId, 3, 30);
+    expect(mockCount).toHaveBeenCalledWith(projectId);
+    expect(result).toEqual({
+      scenarios: [],
+      total: 61,
+      page: 3,
+      limit: 30,
+      totalPages: 3,
+    });
+  });
+
+  it("returns an empty page for an unknown project without disclosing records", async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    const result = await testScenarioService.listScenarios({
+      projectId: otherProjectId,
+    });
+
+    expect(result.scenarios).toEqual([]);
+    expect(result.totalPages).toBe(0);
+    expect(mockFindMany).toHaveBeenCalledWith(otherProjectId, 1, 30);
+  });
+
+  it("classifies cross-project detail access as not found", async () => {
+    mockFindById.mockResolvedValue(null);
+
+    await expect(
+      testScenarioService.getScenarioById(scenario.id, otherProjectId),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(mockFindById).toHaveBeenCalledWith(scenario.id, otherProjectId);
+  });
+
+  it("classifies invalid service pagination as validation failure", async () => {
+    await expect(
+      testScenarioService.listScenarios({ projectId, page: 0, limit: 30 }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+  });
+
+  it("deletes only the requested project scenario", async () => {
+    await testScenarioService.deleteScenario(scenario.id, projectId);
+
+    expect(mockDelete).toHaveBeenCalledWith(scenario.id, projectId);
+  });
+
+  it("does not report deletion success when the composite identity is absent", async () => {
+    mockDelete.mockResolvedValue(0);
+
+    await expect(
+      testScenarioService.deleteScenario(scenario.id, otherProjectId),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+  });
+});

--- a/__tests__/test-scenarios/testScenarioWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioWorkflow.test.ts
@@ -1,0 +1,185 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+import { executeController } from "@/test-utils/httpMocks";
+
+const mockProjects = new Set<string>();
+const mockScenarios: TestScenario[] = [];
+let mockNextId = 0;
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: jest.fn((projectId: string) =>
+      Promise.resolve(mockProjects.has(projectId)),
+    ),
+  },
+}));
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    create: jest.fn((data: {
+      projectId: string;
+      title: string;
+      contentMd: string;
+      createdById: string;
+    }) => {
+      mockNextId += 1;
+      const scenario: TestScenario = {
+        id: `00000000-0000-0000-0000-${String(mockNextId).padStart(12, "0")}`,
+        projectId: data.projectId,
+        createdById: data.createdById,
+        title: data.title,
+        contentMd: data.contentMd,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      };
+      mockScenarios.push(scenario);
+      return Promise.resolve(scenario);
+    }),
+    findMany: jest.fn(
+      (projectId: string, pageInput?: number, limitInput?: number) => {
+        const page = pageInput ?? 1;
+        const limit = limitInput ?? 30;
+      const matching = mockScenarios
+        .filter((scenario) => scenario.projectId === projectId)
+        .sort((left, right) => right.id.localeCompare(left.id));
+      const start = (page - 1) * limit;
+      return Promise.resolve(matching.slice(start, start + limit));
+      },
+    ),
+    count: jest.fn((projectId: string) =>
+      Promise.resolve(
+        mockScenarios.filter((scenario) => scenario.projectId === projectId)
+          .length,
+      ),
+    ),
+    findById: jest.fn((id: string, projectId: string) =>
+      Promise.resolve(
+        mockScenarios.find(
+          (scenario) => scenario.id === id && scenario.projectId === projectId,
+        ) ?? null,
+      ),
+    ),
+    delete: jest.fn((id: string, projectId: string) => {
+      const index = mockScenarios.findIndex(
+        (scenario) => scenario.id === id && scenario.projectId === projectId,
+      );
+      if (index === -1) return Promise.resolve(0);
+      mockScenarios.splice(index, 1);
+      return Promise.resolve(1);
+    }),
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+
+const projectA = "11111111-1111-1111-1111-111111111111";
+const projectB = "22222222-2222-2222-2222-222222222222";
+const creatorId = "33333333-3333-3333-3333-333333333333";
+const spoofedCreatorId = "44444444-4444-4444-4444-444444444444";
+const authenticatedUser = {
+  id: creatorId,
+  name: "Scenario Creator",
+  email: "creator@example.com",
+  status: "active",
+  role: "member",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+} as const;
+
+describe("test-scenario project-isolated workflow", () => {
+  beforeEach(() => {
+    mockProjects.clear();
+    mockScenarios.length = 0;
+    mockNextId = 0;
+    mockProjects.add(projectA);
+    mockProjects.add(projectB);
+  });
+
+  it("round-trips Markdown, paginates deterministically, and isolates projects", async () => {
+    const exactMarkdown = "# Heading\n\n  ✓ indented\n\n```ts\nconst x = 1;\n```\n";
+    const first = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: {
+        projectId: projectA,
+        title: "  First  ",
+        contentMd: exactMarkdown,
+        createdById: spoofedCreatorId,
+      },
+    });
+    const second = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: projectA, title: "Second", contentMd: "## Second" },
+    });
+    await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: projectB, title: "Other project", contentMd: "# Other" },
+    });
+
+    expect(first.statusCode).toBe(201);
+    expect((first.body as TestScenario).title).toBe("First");
+    expect((first.body as TestScenario).createdById).toBe(creatorId);
+    expect((first.body as TestScenario).createdById).not.toBe(spoofedCreatorId);
+    expect((first.body as TestScenario).contentMd).toBe(exactMarkdown);
+
+    const pageOne = await executeController(testScenarioController.list, {
+      query: { projectId: projectA, page: "1", limit: "1" },
+    });
+    expect(pageOne.body).toEqual(expect.objectContaining({
+      total: 2,
+      page: 1,
+      limit: 1,
+      totalPages: 2,
+    }));
+    expect((pageOne.body as { scenarios: TestScenario[] }).scenarios).toHaveLength(1);
+
+    const pageTwo = await executeController(testScenarioController.list, {
+      query: { projectId: projectA, page: "2", limit: "1" },
+    });
+    expect((pageTwo.body as { scenarios: TestScenario[] }).scenarios[0]?.title).toBe(
+      "First",
+    );
+
+    const scenarioId = (first.body as TestScenario).id;
+    const crossProjectDetail = await executeController(
+      testScenarioController.getById,
+      { params: { scenarioId }, query: { projectId: projectB } },
+    );
+    expect(crossProjectDetail.statusCode).toBe(404);
+
+    const crossProjectDelete = await executeController(
+      testScenarioController.delete,
+      { method: "DELETE", params: { scenarioId }, query: { projectId: projectB } },
+    );
+    expect(crossProjectDelete.statusCode).toBe(404);
+
+    const detail = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId: projectA },
+    });
+    expect(detail.statusCode).toBe(200);
+    expect((detail.body as TestScenario).contentMd).toBe(exactMarkdown);
+
+    const deleteResponse = await executeController(testScenarioController.delete, {
+      method: "DELETE",
+      params: { scenarioId },
+      query: { projectId: projectA },
+    });
+    expect(deleteResponse.statusCode).toBe(204);
+
+    const remaining = await executeController(testScenarioController.list, {
+      query: { projectId: projectA },
+    });
+    expect((remaining.body as { scenarios: TestScenario[] }).scenarios).toHaveLength(1);
+    expect((remaining.body as { scenarios: TestScenario[] }).scenarios[0]?.title).toBe(
+      "Second",
+    );
+    expect(second.statusCode).toBe(201);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ export default [
       "dist/**",
       "node_modules/**",
       "backup-js-files/**",
+      ".agents/**",
       "__mocks__/**",
       "*.d.ts",
       "jest.config.ts",

--- a/openspec/changes/add-markdown-test-scenarios/.openspec.yaml
+++ b/openspec/changes/add-markdown-test-scenarios/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/add-markdown-test-scenarios/design.md
+++ b/openspec/changes/add-markdown-test-scenarios/design.md
@@ -1,0 +1,110 @@
+## Context
+
+The backend currently persists execution-imported `Spec` records, but it has no domain model for human-authored test scenarios. Issue #72 introduces that model as a deliberately independent REST-only slice. The implementation must follow the existing routes → controllers → services → models layering, use Prisma/PostgreSQL persistence, publish Zod-backed OpenAPI contracts, and retain the repository's `{ error: string }` error envelope.
+
+Projects are the existing domain boundary. Authentication establishes an active user, while most current project-scoped resources enforce context by including `projectId` in data queries rather than performing per-resource owner authorization. This change preserves those current project-access semantics and does not attempt a partial authorization redesign.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist project-owned scenarios with a title and raw Markdown source.
+- Record the authenticated creator of every scenario.
+- Expose authenticated create, paginated list, detail, and delete operations.
+- Make cross-project scenario access impossible when a scenario ID is used with a different requested project ID.
+- Preserve `contentMd` exactly after it passes request validation.
+- Provide deterministic pagination and one documented response shape.
+- Keep scenario deletion isolated from all execution and issue data.
+- Preserve successful project deletion when its project has scenarios.
+
+**Non-Goals:**
+
+- Updating scenarios or tracking revisions.
+- Rendering, parsing, sanitizing, or semantically validating Markdown.
+- Connecting scenarios to `Spec`, `Result`, `ResultError`, `Assumption`, `Issue`, or executions.
+- MCP tools, client UI, suites/folders, attachments, archive/restore, manual runs, or Git-backed storage.
+- Introducing project-owner authorization across existing APIs.
+
+## Decisions
+
+### 1. Use a separate relational model with no execution-domain links
+
+Add `TestScenario` with UUID `id`, `projectId`, and required `createdById`; string `title`; PostgreSQL text `contentMd`; and Prisma-managed `createdAt`/`updatedAt`. Add `Project.testScenarios` and a named `User.testScenariosCreated` / `TestScenario.createdBy` relation, plus indexes for project and creator access. There will be no relation to the existing `Spec` model or downstream execution and issue models.
+
+This enforces domain separation in the schema, records durable creator attribution, and makes direct scenario deletion a single-record operation. Reusing `Spec` was rejected because its uniqueness, imported metadata, and result relationships give it a different lifecycle. Creator attribution is required because scenario creation is always authenticated and the current user lifecycle suspends users rather than deleting them.
+
+### 2. Use the existing flat resource URL style
+
+The REST contract will use:
+
+- `POST /api/v2/test-scenarios` with `{ projectId, title, contentMd }` in the body.
+- `GET /api/v2/test-scenarios?projectId=...&page=...&limit=...`.
+- `GET /api/v2/test-scenarios/{scenarioId}?projectId=...`.
+- `DELETE /api/v2/test-scenarios/{scenarioId}?projectId=...`.
+
+Body/query placement follows comparable existing `/v2/issues`, `/v2/specs`, and `/v2/executions` APIs and matches the issue's prescribed paths. Nested `/projects/{projectId}/test-scenarios` routes were rejected because they would create a new URL convention beyond this issue.
+
+### 3. Validate transport input with shared Zod schemas
+
+Runtime request schemas will validate UUIDs, a non-blank title, non-empty string `contentMd`, and integer pagination. The title will be trimmed before persistence; `contentMd` will not be trimmed or line-ending-normalized. Accepted Markdown is opaque source text: the backend validates its presence and type, not Markdown grammar.
+
+Pagination defaults to page `1` and limit `30`; page and limit must be positive integers and limit is capped at `100`. The same schema definitions or equivalent constraints will drive the OpenAPI contract to prevent runtime/documentation drift.
+
+### 4. Derive creator attribution from authentication
+
+The controller will pass `req.user.id` to the service as `createdById`. The create request body will remain `{ projectId, title, contentMd }`; `createdById` is not client-selectable. If an undeclared creator field is submitted, it cannot override the authenticated identity used for persistence.
+
+Create, list, and detail resource representations will include `createdById`. Nested user profile data is not included in this issue because the requested audit field only requires a stable user reference and returning profile data would expand the response and query contracts. Creator attribution records who created a scenario; it does not grant or restrict read/delete authorization.
+
+### 5. Return a domain-specific stable pagination envelope
+
+List responses will have this shape:
+
+```json
+{
+  "scenarios": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+Records will be ordered by `createdAt DESC` and then `id DESC` so offset pagination is deterministic even when timestamps match. A bare array was rejected because it cannot carry pagination metadata. The unused generic pagination type was not selected because existing resource APIs expose domain-named collections.
+
+### 6. Enforce project scope in every identity-bearing query
+
+Detail lookup and the existence check preceding deletion will filter by both `id` and `projectId`; list and count will share the exact same project predicate. A mismatched or unknown `(scenarioId, projectId)` pair returns `404`, which prevents cross-project mutation and avoids revealing whether the ID exists elsewhere.
+
+Authentication remains mandatory on all four routes. Additional `Project.ownerId` authorization is not introduced because that would be inconsistent with current access semantics and is broader than issue #72.
+
+### 7. Use explicit domain errors and the common error envelope
+
+The scenario service will distinguish validation, not-found, and unexpected failures without controller string matching. Controllers will consistently map them to `400`, `404`, and `500`, while `authMiddleware` retains responsibility for `401`. Error bodies remain `{ "error": "..." }`; successful creation returns `201`, reads return `200`, and deletion returns an empty `204` response.
+
+Creation will verify that the referenced project exists and return `404` when it does not, rather than exposing a Prisma foreign-key error. Unknown projects on a list naturally return an empty page because the operation has no scenario identity to disclose.
+
+### 8. Extend manual project deletion ordering
+
+The existing project model manually deletes related records in a transaction. It will delete `TestScenario` rows before deleting the project. Database-level cascading was rejected for this isolated relation because it would mix deletion strategies inside the same aggregate and make project deletion behavior less explicit.
+
+## Risks / Trade-offs
+
+- **[Risk] Offset pagination can shift when scenarios are inserted between page requests.** → Use deterministic ordering now; cursor pagination can be introduced later without changing stored data.
+- **[Risk] Unbounded Markdown can create large rows or responses.** → Keep this issue faithful to its raw-text requirement and the server's existing request-size controls; introduce a product-defined field limit separately if needed.
+- **[Risk] Authentication without owner authorization permits the same project access currently available in other domain APIs.** → Enforce exact project context here and address owner authorization consistently across project resources in a dedicated security change.
+- **[Risk] Forgetting the manual project-deletion update causes foreign-key failures.** → Include project deletion with scenarios in model/service regression coverage.
+- **[Risk] Accepting `createdById` from request input would allow creator spoofing.** → Exclude it from the request schema and always take the persisted value from `req.user.id`.
+- **[Risk] A required creator foreign key would prevent hard deletion of referenced users.** → The current lifecycle suspends users instead of deleting them; define explicit reassignment or retention semantics before adding hard user deletion.
+- **[Trade-off] Title normalization differs from Markdown preservation.** → Trim only the identifying display title; treat Markdown as opaque source and assert exact round trips in tests.
+
+## Migration Plan
+
+1. Replace the not-yet-finalized initial test-scenario migration with an updated migration that creates the table with both project and required creator foreign keys and their indexes. No data backfill is required because the original migration may be dropped during this implementation phase.
+2. Generate Prisma types before compiling the new model/service code.
+3. Deploy the replacement additive migration before or with the compatible application version; existing production rows and APIs require no backfill.
+4. Roll back application routes before dropping the `TestScenario` table if rollback is necessary. Because no existing domain rows are changed, rollback affects only newly created scenarios.
+
+## Open Questions
+
+None for issue #72. Content-size policy, project-owner authorization, update semantics, and future domain links require separate product decisions and changes.

--- a/openspec/changes/add-markdown-test-scenarios/proposal.md
+++ b/openspec/changes/add-markdown-test-scenarios/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The backend has no first-class model for authored test scenarios, so test-management clients cannot persist Markdown scenario definitions independently from execution-imported specs. This change introduces the first project-scoped test-management slice while deliberately keeping imported execution data and authored scenarios separate.
+
+## What Changes
+
+- Add a project-owned `TestScenario` persistence model containing a title, raw Markdown content, creator attribution, and timestamps.
+- Add authenticated REST operations to create, list, retrieve, and delete test scenarios.
+- Derive each scenario's creator from the authenticated user rather than accepting creator identity from request input.
+- Scope every list, detail, and delete operation to the requested project so scenario identifiers cannot be used across project contexts.
+- Preserve accepted Markdown content exactly across create and read operations without parsing, rendering, or normalization.
+- Add deterministic, validated pagination with a documented response envelope for scenario lists.
+- Delete scenarios independently without modifying imported specs, results, result errors, assumptions, issues, or executions.
+- Keep editing, domain links, MCP tools, client UI, history, attachments, organization, and manual-run support out of scope.
+- Document the new schemas, operations, and error responses in OpenAPI and add migration and regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `markdown-test-scenarios`: Defines project-scoped persistence and authenticated create, paginated list, detail, and delete behavior for raw Markdown test scenarios.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Prisma schema, generated client, replaceable initial migration, user/project relations, and project deletion ordering.
+- New test-scenario route, controller, service, model, validation schemas, shared types, and central route registration.
+- OpenAPI schemas, route registration, API tag metadata, and contract tests.
+- Model, service, controller, route, migration, deletion-isolation, and Markdown round-trip tests.
+- GitHub tracking issue: https://github.com/VENTIONINC/TestPortal-backend/issues/72

--- a/openspec/changes/add-markdown-test-scenarios/specs/markdown-test-scenarios/spec.md
+++ b/openspec/changes/add-markdown-test-scenarios/specs/markdown-test-scenarios/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Test scenarios are independent project-owned records
+The system SHALL persist each test scenario with a UUID identifier, project identifier, required creator user identifier, title, raw Markdown content, creation timestamp, and update timestamp. A test scenario SHALL belong to exactly one existing project, SHALL reference exactly one creating user, and SHALL have no persistence relationship to Specs, Results, ResultErrors, Assumptions, Issues, or Executions.
+
+#### Scenario: Scenario is stored independently
+- **WHEN** a valid scenario is created for an existing project
+- **THEN** the system stores one `TestScenario` record associated with that project
+- **AND** the record's `createdById` references the authenticated user who created it
+- **AND** the system does not create or modify any Spec, Result, ResultError, Assumption, Issue, or Execution record
+
+### Requirement: Authenticated clients can create Markdown scenarios
+The system SHALL expose `POST /api/v2/test-scenarios` to authenticated clients. The request SHALL contain a valid project UUID, a non-blank title, and a non-empty string `contentMd`. The system SHALL derive `createdById` from the authenticated user, SHALL NOT permit request input to select or override the creator, SHALL trim the title, SHALL preserve accepted `contentMd` exactly without parsing or normalization, and SHALL return the created scenario with HTTP 201.
+
+#### Scenario: Create a scenario containing Markdown
+- **WHEN** an authenticated client submits a valid project ID, title, and Markdown source
+- **THEN** the system returns HTTP 201 with the persisted scenario
+- **AND** the response includes its ID, project ID, creator user ID, trimmed title, exact Markdown source, creation timestamp, and update timestamp
+
+#### Scenario: Client cannot spoof the creator
+- **WHEN** an authenticated client submits a create request containing an undeclared creator identifier for a different user
+- **THEN** the system stores the authenticated user's ID as `createdById`
+- **AND** the client-supplied creator value does not affect persistence
+
+#### Scenario: Markdown survives a create and read round trip
+- **WHEN** an authenticated client creates a scenario whose content contains headings, Unicode, code fences, indentation, and line breaks
+- **THEN** the `contentMd` returned by create and subsequent detail retrieval exactly equals the submitted `contentMd`
+
+#### Scenario: Create request is invalid
+- **WHEN** an authenticated client submits a malformed project ID, blank title, missing field, non-string content, or empty `contentMd`
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** no scenario is created
+
+#### Scenario: Project does not exist
+- **WHEN** an authenticated client submits a valid project UUID that identifies no project
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no scenario is created
+
+### Requirement: Authenticated clients can list scenarios by project
+The system SHALL expose `GET /api/v2/test-scenarios` to authenticated clients and SHALL require a valid `projectId` query parameter. Each returned scenario SHALL include its `createdById`. The endpoint SHALL return only scenarios belonging to that project and SHALL never include scenario Markdown or records from another project context by mistake.
+
+#### Scenario: List contains only requested-project scenarios
+- **WHEN** scenarios exist in multiple projects and a client lists one project
+- **THEN** every returned scenario has the requested project ID
+- **AND** no scenario from another project is returned
+
+#### Scenario: Unknown project has no scenarios
+- **WHEN** an authenticated client lists a syntactically valid project UUID with no matching scenarios
+- **THEN** the system returns HTTP 200 with an empty `scenarios` array and zero pagination totals
+
+### Requirement: Scenario lists are validated and deterministically paginated
+The list endpoint SHALL accept positive integer `page` and `limit` parameters, default page to 1, default limit to 30, and reject limits greater than 100. It SHALL order records by creation time descending and then ID descending. It SHALL return exactly `scenarios`, `total`, `page`, `limit`, and `totalPages` as its top-level pagination fields.
+
+#### Scenario: Default pagination is returned
+- **WHEN** an authenticated client lists scenarios with a project ID and omits page and limit
+- **THEN** the system returns the first page with limit 30
+- **AND** `total` and `totalPages` describe all scenarios in the requested project
+
+#### Scenario: Explicit page is returned
+- **WHEN** an authenticated client requests a valid page and limit
+- **THEN** the system returns the matching deterministic slice
+- **AND** echoes the resolved page and limit in the response
+
+#### Scenario: Pagination is invalid
+- **WHEN** page or limit is non-numeric, fractional, zero, negative, or limit exceeds 100
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Authenticated clients can retrieve a scenario within a project context
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}` to authenticated clients and SHALL require valid `scenarioId` and `projectId` UUIDs. The lookup SHALL match both identifiers.
+
+#### Scenario: Retrieve a matching scenario
+- **WHEN** an authenticated client requests an existing scenario with its owning project ID
+- **THEN** the system returns HTTP 200 with the complete scenario, including exact Markdown source
+- **AND** the response identifies the scenario's creator through `createdById`
+
+#### Scenario: Scenario is absent from the requested project context
+- **WHEN** the scenario does not exist or belongs to a different project than the requested project ID
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+
+#### Scenario: Detail identifiers are invalid
+- **WHEN** an authenticated client supplies a missing or malformed project ID or malformed scenario ID
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Authenticated clients can delete only the requested-project scenario
+The system SHALL expose `DELETE /api/v2/test-scenarios/{scenarioId}` to authenticated clients and SHALL require valid `scenarioId` and `projectId` UUIDs. Deletion SHALL remove only the scenario matching both identifiers and SHALL return an empty HTTP 204 response.
+
+#### Scenario: Delete a matching scenario
+- **WHEN** an authenticated client deletes an existing scenario with its owning project ID
+- **THEN** the system returns HTTP 204 with no response body
+- **AND** subsequent retrieval of that scenario in the same project returns HTTP 404
+
+#### Scenario: Cross-project delete is rejected
+- **WHEN** an authenticated client supplies an existing scenario ID with a different project ID
+- **THEN** the system returns HTTP 404
+- **AND** the scenario remains stored in its owning project
+
+#### Scenario: Scenario deletion leaves other domains unchanged
+- **WHEN** a scenario is deleted from a project that also has Specs, Results, ResultErrors, Assumptions, Issues, and Executions
+- **THEN** none of those records are modified or deleted
+
+### Requirement: Project deletion remains valid with scenarios
+The system SHALL remove a project's test scenarios as part of the existing transactional project deletion flow before deleting the project itself.
+
+#### Scenario: Delete a project containing scenarios
+- **WHEN** the existing project deletion operation deletes a project that has test scenarios
+- **THEN** all scenarios belonging to that project are removed
+- **AND** project deletion completes without a foreign-key failure
+
+### Requirement: Scenario APIs require authentication and have documented contracts
+All test-scenario routes SHALL use the existing JWT authentication middleware. OpenAPI SHALL document `createdById` as a required scenario response field but not as create-request input. OpenAPI SHALL also document request parameters and bodies, success schemas, the stable pagination envelope, bearer authentication, and applicable 400, 401, 404, and 500 error responses using the common error schema.
+
+#### Scenario: Request is unauthenticated
+- **WHEN** a client calls any test-scenario route without a valid authentication token
+- **THEN** the system returns HTTP 401 with an `{ "error": string }` response
+- **AND** no scenario data is returned or mutated
+
+#### Scenario: OpenAPI document is generated
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** all four test-scenario operations and their request and response schemas are present under a Test Scenarios tag

--- a/openspec/changes/add-markdown-test-scenarios/tasks.md
+++ b/openspec/changes/add-markdown-test-scenarios/tasks.md
@@ -1,0 +1,54 @@
+## 1. Persistence Model and Migration
+
+- [x] 1.1 Add the project relation and independent `TestScenario` Prisma model with UUID identifiers, raw text content, timestamps, and project-oriented indexes.
+- [x] 1.2 Create and review the forward Prisma migration for the test-scenario table, foreign key, and indexes, then regenerate the Prisma client.
+- [x] 1.3 Extend the transactional project-deletion model flow to remove project scenarios before deleting the project.
+- [x] 1.4 Add migration/schema regression coverage proving the new table contract and independence from execution and issue tables.
+
+## 2. Request Contracts and Domain Types
+
+- [x] 2.1 Create header-compliant test-scenario schema/type files using the repository new-file workflow.
+- [x] 2.2 Define shared Zod validation for create input, scenario/project identifiers, and page/limit query parameters with defaults and the limit cap.
+- [x] 2.3 Define typed scenario responses, domain errors, and the stable `{ scenarios, total, page, limit, totalPages }` list envelope without using `any`.
+
+## 3. Model and Service Layers
+
+- [x] 3.1 Implement the test-scenario model create, project-filtered list/count, composite detail lookup, and composite delete support with deterministic ordering.
+- [x] 3.2 Add model tests for create data, project isolation, list/count predicate alignment, ordering, pagination offsets, composite lookup, and composite deletion.
+- [x] 3.3 Implement the test-scenario service for project existence checks, title normalization, exact Markdown preservation, paginated reads, not-found behavior, and isolated deletion.
+- [x] 3.4 Add service tests for Markdown round trips, pagination metadata, unknown projects, cross-project access, domain-error classification, and deletion isolation.
+
+## 4. Controller and Route Integration
+
+- [x] 4.1 Implement controller handlers for create, list, detail, and delete with shared Zod validation and consistent 201/200/204/400/404/500 responses.
+- [x] 4.2 Register all four `/api/v2/test-scenarios` routes behind `authMiddleware` and mount the router in the central API router.
+- [x] 4.3 Add controller tests for accepted and rejected inputs, status/error mappings, stable list responses, exact Markdown responses, and empty 204 deletion.
+- [x] 4.4 Add route tests proving JWT protection, route wiring, query/body handoff, and the absence of update or MCP operations.
+
+## 5. OpenAPI Contract
+
+- [x] 5.1 Add OpenAPI component schemas for scenario resources, create input, identifiers, pagination queries, and the stable list response.
+- [x] 5.2 Register the four test-scenario operations, bearer security, success responses, and common 400/401/404/500 error responses.
+- [x] 5.3 Register the Test Scenarios tag and route registrar in the generated OpenAPI document.
+- [x] 5.4 Add OpenAPI contract tests asserting operation presence, request/response schemas, pagination constraints, authentication, and documented errors.
+
+## 6. Cross-Domain Regression Coverage
+
+- [x] 6.1 Add regression coverage proving scenario deletion changes only the selected `TestScenario` record and leaves Specs, Results, ResultErrors, Assumptions, Issues, and Executions unchanged.
+- [x] 6.2 Add project-deletion regression coverage proving scenarios are removed transactionally without foreign-key failures.
+- [x] 6.3 Add end-to-end create/list/detail/delete coverage across two project contexts, including cross-project 404 behavior and deterministic pagination.
+
+## 7. Verification
+
+- [x] 7.1 Run `npm run type-check` and resolve all strict TypeScript errors.
+- [x] 7.2 Run `npm run lint` and resolve all ESLint or license-header violations.
+- [x] 7.3 Run `npm test` and confirm the complete Jest suite passes.
+- [x] 7.4 Run `npm run build` and confirm the production build succeeds.
+
+## 8. Creator Attribution Amendment
+
+- [x] 8.1 Replace the disposable initial test-scenario migration and update the Prisma schema with required `createdById`, the named User/TestScenario relation, and a creator index, then regenerate the Prisma client.
+- [x] 8.2 Thread the authenticated user's ID from the controller through service and model creation without adding `createdById` to the public create-request schema.
+- [x] 8.3 Add `createdById` to scenario response types and OpenAPI response schemas while keeping it absent from create input.
+- [x] 8.4 Update migration, model, service, controller, route, workflow, and OpenAPI tests for required creator persistence, response exposure, and creator-spoofing prevention.
+- [x] 8.5 Re-run `npm run type-check`, `npm run lint`, `npm test`, and `npm run build` after the creator-attribution changes.

--- a/prisma/migrations/20260824120000_add_test_scenarios/migration.sql
+++ b/prisma/migrations/20260824120000_add_test_scenarios/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "TestScenario" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "contentMd" TEXT NOT NULL,
+    "createdById" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+
+    CONSTRAINT "TestScenario_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TestScenario_projectId_idx" ON "TestScenario"("projectId");
+
+-- CreateIndex
+CREATE INDEX "TestScenario_projectId_createdAt_idx" ON "TestScenario"("projectId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "TestScenario_createdById_idx" ON "TestScenario"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "TestScenario" ADD CONSTRAINT "TestScenario_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestScenario" ADD CONSTRAINT "TestScenario_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Project {
   executions    Execution[]
   specs         Spec[]
   issues        Issue[]
+  testScenarios TestScenario[]
   uploadApiKeys UploadApiKey[]
   dailyMetrics  DailyExecutionMetric[]
 
@@ -171,10 +172,11 @@ model User {
   analyzeEnabled          Boolean  @default(false)
 
   // Project relationships
-  projects      Project[]
-  issuesCreated Issue[]        @relation("IssuesCreated")
-  issuesUpdated Issue[]        @relation("IssuesUpdated")
-  uploadApiKeys UploadApiKey[]
+  projects             Project[]
+  issuesCreated        Issue[]        @relation("IssuesCreated")
+  issuesUpdated        Issue[]        @relation("IssuesUpdated")
+  testScenariosCreated TestScenario[] @relation("TestScenarioCreatedBy")
+  uploadApiKeys        UploadApiKey[]
 }
 
 model Issue {
@@ -201,6 +203,23 @@ model Issue {
   @@index([projectId])
   @@index([projectId, category])
   @@index([projectId, createdAt])
+}
+
+model TestScenario {
+  id          String   @id @default(uuid()) @db.Uuid
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  title       String
+  contentMd   String   @db.Text
+  createdById String   @db.Uuid
+
+  project   Project @relation(fields: [projectId], references: [id])
+  projectId String  @db.Uuid
+  createdBy User    @relation("TestScenarioCreatedBy", fields: [createdById], references: [id])
+
+  @@index([projectId])
+  @@index([projectId, createdAt])
+  @@index([createdById])
 }
 
 model UploadApiKey {

--- a/src/controllers/testScenarioController.ts
+++ b/src/controllers/testScenarioController.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Request, Response } from "express";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  createTestScenarioSchema,
+  testScenarioIdParamsSchema,
+  testScenarioListQuerySchema,
+  testScenarioProjectQuerySchema,
+} from "@/schemas/testScenarioSchemas";
+import { testScenarioService } from "@/services/testScenarioService";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+} from "@/types/testScenarios";
+
+function validationMessage(error: { issues: Array<{ message: string }> }): string {
+  return error.issues[0]?.message ?? "Invalid request";
+}
+
+function sendValidationError(res: Response, message: string): void {
+  res.status(400).json({ error: message });
+}
+
+function sendServiceError(res: Response, error: unknown, operation: string): void {
+  if (error instanceof TestScenarioValidationError) {
+    res.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (error instanceof TestScenarioNotFoundError) {
+    res.status(404).json({ error: error.message });
+    return;
+  }
+
+  const message = error instanceof Error ? error.message : "Unknown error";
+  res.status(500).json({ error: `Failed to ${operation}. ${message}` });
+}
+
+export const testScenarioController = {
+  async create(req: AuthenticatedRequest, res: Response): Promise<void> {
+    if (!req.user) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    const parsed = createTestScenarioSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, validationMessage(parsed.error));
+      return;
+    }
+
+    try {
+      const scenario = await testScenarioService.createScenario({
+        ...parsed.data,
+        createdById: req.user.id,
+      });
+      res.status(201).json(scenario);
+    } catch (error) {
+      sendServiceError(res, error, "create test scenario");
+    }
+  },
+
+  async list(req: Request, res: Response): Promise<void> {
+    const parsed = testScenarioListQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, validationMessage(parsed.error));
+      return;
+    }
+
+    try {
+      const response = await testScenarioService.listScenarios(parsed.data);
+      res.status(200).json(response);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenarios");
+    }
+  },
+
+  async getById(
+    req: Request<{ scenarioId: string }>,
+    res: Response,
+  ): Promise<void> {
+    const params = testScenarioIdParamsSchema.safeParse(req.params);
+    const query = testScenarioProjectQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const scenario = await testScenarioService.getScenarioById(
+        params.data.scenarioId,
+        query.data.projectId,
+      );
+      res.status(200).json(scenario);
+    } catch (error) {
+      sendServiceError(res, error, "fetch test scenario");
+    }
+  },
+
+  async delete(
+    req: Request<{ scenarioId: string }>,
+    res: Response,
+  ): Promise<void> {
+    const params = testScenarioIdParamsSchema.safeParse(req.params);
+    const query = testScenarioProjectQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      await testScenarioService.deleteScenario(
+        params.data.scenarioId,
+        query.data.projectId,
+      );
+      res.status(204).send();
+    } catch (error) {
+      sendServiceError(res, error, "delete test scenario");
+    }
+  },
+};

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -26,6 +26,7 @@ import { registerCtrfRoutes } from "./ctrf";
 import { registerUploadApiKeyRoutes } from "./uploadApiKey";
 import { registerAnalysisExportRoutes } from "./analysisExport";
 import { registerPdfExportRoutes } from "./pdfExport";
+import { registerTestScenarioRoutes } from "./testScenarios";
 import "./zod";
 
 export function generateOpenAPISpec() {
@@ -51,6 +52,7 @@ export function generateOpenAPISpec() {
   registerUploadApiKeyRoutes(registry);
   registerAnalysisExportRoutes(registry);
   registerPdfExportRoutes(registry);
+  registerTestScenarioRoutes(registry);
 
   const generator = new OpenApiGeneratorV31(registry.definitions);
 
@@ -87,6 +89,10 @@ export function generateOpenAPISpec() {
       {
         name: "Specs",
         description: "Test specification endpoints",
+      },
+      {
+        name: "Test Scenarios",
+        description: "Project-scoped authored Markdown test scenario endpoints",
       },
       {
         name: "Assumptions",

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -1,0 +1,255 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { ErrorResponseSchema } from "./common";
+import { z } from "./zod";
+
+const TestScenarioSchema = z
+  .object({
+    id: z.string().uuid(),
+    projectId: z.string().uuid(),
+    createdById: z.string().uuid(),
+    title: z.string(),
+    contentMd: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("TestScenario");
+
+const CreateTestScenarioRequestSchema = z
+  .object({
+    projectId: z.string().uuid(),
+    title: z.string().min(1),
+    contentMd: z.string().min(1),
+  })
+  .openapi("CreateTestScenarioRequest");
+
+const TestScenarioIdParamsSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+  })
+  .openapi("TestScenarioIdParams");
+
+const TestScenarioProjectQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+  })
+  .openapi("TestScenarioProjectQuery");
+
+const TestScenarioListQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioListQuery");
+
+const TestScenarioListResponseSchema = z
+  .object({
+    scenarios: z.array(TestScenarioSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioListResponse");
+
+export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
+  registry.register("TestScenario", TestScenarioSchema);
+  registry.register(
+    "CreateTestScenarioRequest",
+    CreateTestScenarioRequestSchema,
+  );
+  registry.register("TestScenarioIdParams", TestScenarioIdParamsSchema);
+  registry.register(
+    "TestScenarioProjectQuery",
+    TestScenarioProjectQuerySchema,
+  );
+  registry.register("TestScenarioListQuery", TestScenarioListQuerySchema);
+  registry.register(
+    "TestScenarioListResponse",
+    TestScenarioListResponseSchema,
+  );
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v2/test-scenarios",
+    description: "Creates a project-scoped Markdown test scenario.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: CreateTestScenarioRequestSchema,
+          },
+        },
+      },
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      201: {
+        description: "Test scenario created",
+        content: {
+          "application/json": { schema: TestScenarioSchema },
+        },
+      },
+      400: {
+        description: "Invalid test scenario input",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Project not found",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios",
+    description: "Lists project-scoped Markdown test scenarios.",
+    request: {
+      query: TestScenarioListQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated test scenarios",
+        content: {
+          "application/json": { schema: TestScenarioListResponseSchema },
+        },
+      },
+      400: {
+        description: "Invalid project or pagination query",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}",
+    description: "Retrieves a test scenario within a project context.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Test scenario details",
+        content: {
+          "application/json": { schema: TestScenarioSchema },
+        },
+      },
+      400: {
+        description: "Invalid scenario or project identifier",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Test scenario not found in the requested project",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/v2/test-scenarios/{scenarioId}",
+    description: "Deletes a test scenario within a project context.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      204: {
+        description: "Test scenario deleted",
+      },
+      400: {
+        description: "Invalid scenario or project identifier",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Test scenario not found in the requested project",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+}
+
+export {
+  CreateTestScenarioRequestSchema,
+  TestScenarioIdParamsSchema,
+  TestScenarioListQuerySchema,
+  TestScenarioListResponseSchema,
+  TestScenarioProjectQuerySchema,
+  TestScenarioSchema,
+};

--- a/src/models/projectModel.ts
+++ b/src/models/projectModel.ts
@@ -108,6 +108,19 @@ export const projectModel = {
     });
   },
 
+  async exists(
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<boolean> {
+    const client = tx ?? dbClient;
+    const project = await client.project.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+
+    return project !== null;
+  },
+
   async create(
     data: {
       name: string;
@@ -201,9 +214,10 @@ export const projectModel = {
    * 4. Issues (references Project)
    * 5. Executions (references Project)
    * 6. Specs (references Project)
-   * 7. DailyExecutionMetric (references Project)
-   * 8. UploadApiKeys (references Project)
-   * 9. Project itself
+   * 7. TestScenarios (references Project)
+   * 8. DailyExecutionMetric (references Project)
+   * 9. UploadApiKeys (references Project)
+   * 10. Project itself
    */
   async deleteWithCascade(id: string): Promise<Project> {
     return await dbClient.$transaction(async (tx) => {
@@ -301,17 +315,22 @@ export const projectModel = {
         where: { projectId: id },
       });
 
-      // Step 7: Delete DailyExecutionMetric (references Project)
+      // Step 7: Delete TestScenarios (references Project)
+      await tx.testScenario.deleteMany({
+        where: { projectId: id },
+      });
+
+      // Step 8: Delete DailyExecutionMetric (references Project)
       await tx.dailyExecutionMetric.deleteMany({
         where: { projectId: id },
       });
 
-      // Step 8: Delete UploadApiKeys (references Project)
+      // Step 9: Delete UploadApiKeys (references Project)
       await tx.uploadApiKey.deleteMany({
         where: { projectId: id },
       });
 
-      // Step 9: Delete Project itself
+      // Step 10: Delete Project itself
       return await tx.project.delete({
         where: { id },
       });

--- a/src/models/testScenarioModel.ts
+++ b/src/models/testScenarioModel.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Prisma, TestScenario } from "@prisma/client";
+import { dbClient } from "@/prisma/client";
+
+export interface CreateTestScenarioData {
+  projectId: string;
+  title: string;
+  contentMd: string;
+  createdById: string;
+}
+
+const projectWhere = (projectId: string): Prisma.TestScenarioWhereInput => ({
+  projectId,
+});
+
+export const testScenarioModel = {
+  async create(
+    data: CreateTestScenarioData,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.create({ data });
+  },
+
+  async findMany(
+    projectId: string,
+    page = 1,
+    limit = 30,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario[]> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.findMany({
+      where: projectWhere(projectId),
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+  },
+
+  async count(
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.count({
+      where: projectWhere(projectId),
+    });
+  },
+
+  async findById(
+    id: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario | null> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.findFirst({
+      where: { id, projectId },
+    });
+  },
+
+  async delete(
+    id: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    const result = await client.testScenario.deleteMany({
+      where: { id, projectId },
+    });
+
+    return result.count;
+  },
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -20,6 +20,7 @@ import ctrf from "@/routes/ctrf";
 import upload from "@/routes/upload";
 import analysisExport from "@/routes/analysis-export";
 import reports from "@/routes/reports";
+import testScenarios from "@/routes/test-scenarios";
 import mcp from "@/mcp/server";
 
 const router = Router();
@@ -46,6 +47,7 @@ router.use(projects);
 router.use(ctrf);
 router.use(upload);
 router.use(reports);
+router.use(testScenarios);
 router.use(mcp);
 
 export default router;

--- a/src/routes/test-scenarios.ts
+++ b/src/routes/test-scenarios.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { Router } from "express";
+import { testScenarioController } from "@/controllers/testScenarioController";
+import { authMiddleware } from "@/middleware/authMiddleware";
+
+const router = Router();
+
+router.post(
+  "/v2/test-scenarios",
+  authMiddleware,
+  testScenarioController.create,
+);
+router.get(
+  "/v2/test-scenarios",
+  authMiddleware,
+  testScenarioController.list,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId",
+  authMiddleware,
+  testScenarioController.getById,
+);
+router.delete(
+  "/v2/test-scenarios/:scenarioId",
+  authMiddleware,
+  testScenarioController.delete,
+);
+
+export default router;

--- a/src/schemas/testScenarioSchemas.ts
+++ b/src/schemas/testScenarioSchemas.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from "zod";
+
+const uuidSchema = z.string().uuid("Must be a valid UUID");
+
+export const createTestScenarioSchema = z
+  .object({
+    projectId: uuidSchema,
+    title: z.string().trim().min(1, "Title is required"),
+    contentMd: z.string().min(1, "contentMd is required"),
+  });
+
+export const testScenarioProjectQuerySchema = z.object({
+  projectId: uuidSchema,
+});
+
+export const testScenarioIdParamsSchema = z.object({
+  scenarioId: uuidSchema,
+});
+
+const positiveIntegerQuerySchema = (defaultValue: number, maximum?: number) => {
+  const schema = z.coerce
+    .number()
+    .int("Must be an integer")
+    .positive("Must be greater than zero");
+
+  return (maximum === undefined ? schema : schema.max(maximum)).default(
+    defaultValue,
+  );
+};
+
+export const testScenarioListQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export type CreateTestScenarioInput = z.infer<typeof createTestScenarioSchema>;
+export type TestScenarioProjectQuery = z.infer<
+  typeof testScenarioProjectQuerySchema
+>;
+export type TestScenarioIdParams = z.infer<typeof testScenarioIdParamsSchema>;
+export type TestScenarioListQuery = z.infer<
+  typeof testScenarioListQuerySchema
+>;

--- a/src/services/testScenarioService.ts
+++ b/src/services/testScenarioService.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { projectModel } from "@/models/projectModel";
+import { testScenarioModel } from "@/models/testScenarioModel";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+  type CreateTestScenarioParams,
+  type ListTestScenariosParams,
+  type TestScenarioListResponse,
+  type TestScenarioResponse,
+} from "@/types/testScenarios";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+function validatePagination(page: number, limit: number): void {
+  if (!Number.isInteger(page) || page < 1) {
+    throw new TestScenarioValidationError(
+      "page must be a positive integer",
+    );
+  }
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new TestScenarioValidationError(
+      `limit must be a positive integer no greater than ${MAX_LIMIT}`,
+    );
+  }
+}
+
+export const testScenarioService = {
+  async createScenario(
+    params: CreateTestScenarioParams,
+  ): Promise<TestScenarioResponse> {
+    if (!params.title.trim()) {
+      throw new TestScenarioValidationError("Title is required");
+    }
+
+    if (params.contentMd.length === 0) {
+      throw new TestScenarioValidationError("contentMd is required");
+    }
+
+    if (!(await projectModel.exists(params.projectId))) {
+      throw new TestScenarioNotFoundError(
+        `Project with id '${params.projectId}' not found`,
+      );
+    }
+
+    return await testScenarioModel.create({
+      projectId: params.projectId,
+      title: params.title.trim(),
+      contentMd: params.contentMd,
+      createdById: params.createdById,
+    });
+  },
+
+  async listScenarios(
+    params: ListTestScenariosParams,
+  ): Promise<TestScenarioListResponse> {
+    const page = params.page ?? DEFAULT_PAGE;
+    const limit = params.limit ?? DEFAULT_LIMIT;
+    validatePagination(page, limit);
+
+    const [scenarios, total] = await Promise.all([
+      testScenarioModel.findMany(params.projectId, page, limit),
+      testScenarioModel.count(params.projectId),
+    ]);
+
+    return {
+      scenarios,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getScenarioById(
+    scenarioId: string,
+    projectId: string,
+  ): Promise<TestScenarioResponse> {
+    if (!scenarioId) {
+      throw new TestScenarioValidationError("Scenario ID is required");
+    }
+
+    if (!projectId) {
+      throw new TestScenarioValidationError("Project ID is required");
+    }
+
+    const scenario = await testScenarioModel.findById(scenarioId, projectId);
+    if (!scenario) {
+      throw new TestScenarioNotFoundError(
+        `Test scenario with id '${scenarioId}' not found`,
+      );
+    }
+
+    return scenario;
+  },
+
+  async deleteScenario(scenarioId: string, projectId: string): Promise<void> {
+    if (!scenarioId) {
+      throw new TestScenarioValidationError("Scenario ID is required");
+    }
+
+    if (!projectId) {
+      throw new TestScenarioValidationError("Project ID is required");
+    }
+
+    const deletedCount = await testScenarioModel.delete(scenarioId, projectId);
+    if (deletedCount === 0) {
+      throw new TestScenarioNotFoundError(
+        `Test scenario with id '${scenarioId}' not found`,
+      );
+    }
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "@/types/mcp";
 export * from "@/types/tests";
 export * from "@/types/ctrf";
 export * from "@/types/skills";
+export * from "@/types/testScenarios";
 
 // Express types extensions
 import type { Request } from "express";

--- a/src/types/testScenarios.ts
+++ b/src/types/testScenarios.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export interface TestScenarioResponse {
+  id: string;
+  projectId: string;
+  createdById: string;
+  title: string;
+  contentMd: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type TestScenarioRecord = TestScenarioResponse;
+
+export interface CreateTestScenarioParams {
+  projectId: string;
+  title: string;
+  contentMd: string;
+  createdById: string;
+}
+
+export interface ListTestScenariosParams {
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioListResponse {
+  scenarios: TestScenarioResponse[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class TestScenarioValidationError extends Error {
+  readonly code = "TEST_SCENARIO_VALIDATION_ERROR" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioValidationError";
+  }
+}
+
+export class TestScenarioNotFoundError extends Error {
+  readonly code = "TEST_SCENARIO_NOT_FOUND" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioNotFoundError";
+  }
+}


### PR DESCRIPTION
## Summary

- Add project-scoped Markdown test scenario persistence and authenticated REST endpoints.
- Add validation, pagination, OpenAPI documentation, migration coverage, and workflow tests.
- Keep the optional GitHub MCP integration from blocking Codex startup.

## Verification

- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` (369 tests passed)