### PR TITLE
Integrate test scenarios with execution evidence

### DIFF
--- a/__tests__/controllers/testScenarioIntegrationController.test.ts
+++ b/__tests__/controllers/testScenarioIntegrationController.test.ts
@@ -1,0 +1,191 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import { executeController } from "@/test-utils/httpMocks";
+import {
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
+
+const addSpecLinkMock = jest.fn<() => Promise<unknown>>();
+const listSpecLinksMock = jest.fn<() => Promise<unknown>>();
+const removeSpecLinkMock = jest.fn<() => Promise<unknown>>();
+const getResultsMock = jest.fn<() => Promise<unknown>>();
+const getIssuesMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/services/testScenarioService", () => ({
+  testScenarioService: {},
+}));
+jest.mock("@/services/testScenarioIntegrationService", () => ({
+  testScenarioIntegrationService: {
+    addSpecLink: addSpecLinkMock,
+    listSpecLinks: listSpecLinksMock,
+    removeSpecLink: removeSpecLinkMock,
+    getResults: getResultsMock,
+    getIssues: getIssuesMock,
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const specId = "33333333-3333-3333-3333-333333333333";
+
+describe("testScenarioController integration operations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    addSpecLinkMock.mockResolvedValue({ scenarioId, specId });
+    listSpecLinksMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      specs: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    removeSpecLinkMock.mockResolvedValue(undefined);
+    getResultsMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      results: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    getIssuesMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      issues: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+  });
+
+  it("validates and creates a Spec link with 201", async () => {
+    const response = await executeController(testScenarioController.addSpecLink, {
+      method: "POST",
+      params: { scenarioId },
+      query: { projectId },
+      body: { specId },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toEqual({ scenarioId, specId });
+    expect(addSpecLinkMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      specId,
+    });
+  });
+
+  it("rejects malformed link input with 400 before calling the service", async () => {
+    const response = await executeController(testScenarioController.addSpecLink, {
+      params: { scenarioId: "bad" },
+      query: { projectId },
+      body: { specId },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(addSpecLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the default linked-Spec page", async () => {
+    const response = await executeController(testScenarioController.listSpecLinks, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(listSpecLinksMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("maps removal success to an empty 204 and typed misses to 404", async () => {
+    const response = await executeController(testScenarioController.removeSpecLink, {
+      method: "DELETE",
+      params: { scenarioId, specId },
+      query: { projectId },
+    });
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBeUndefined();
+
+    removeSpecLinkMock.mockRejectedValueOnce(
+      new TestScenarioSpecLinkNotFoundError("Link not found"),
+    );
+    const missing = await executeController(testScenarioController.removeSpecLink, {
+      method: "DELETE",
+      params: { scenarioId, specId },
+      query: { projectId },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("returns independently paginated Result and Issue envelopes", async () => {
+    const resultResponse = await executeController(testScenarioController.getResults, {
+      params: { scenarioId },
+      query: { projectId, page: "2", limit: "5" },
+    });
+    const issueResponse = await executeController(testScenarioController.getIssues, {
+      params: { scenarioId },
+      query: { projectId, page: "2", limit: "5" },
+    });
+
+    expect(resultResponse.statusCode).toBe(200);
+    expect(issueResponse.statusCode).toBe(200);
+    expect(getResultsMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 5,
+    });
+    expect(getIssuesMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 5,
+    });
+  });
+
+  it("maps duplicate and unexpected service errors without message inspection", async () => {
+    addSpecLinkMock.mockRejectedValueOnce(
+      new TestScenarioSpecLinkConflictError("already linked"),
+    );
+    const conflict = await executeController(testScenarioController.addSpecLink, {
+      method: "POST",
+      params: { scenarioId },
+      query: { projectId },
+      body: { specId },
+    });
+    expect(conflict.statusCode).toBe(409);
+
+    getIssuesMock.mockRejectedValueOnce(new Error("database unavailable"));
+    const failed = await executeController(testScenarioController.getIssues, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(failed.statusCode).toBe(500);
+  });
+
+  it("rejects evidence pagination above the contract limit", async () => {
+    const response = await executeController(testScenarioController.getResults, {
+      params: { scenarioId },
+      query: { projectId, page: "1", limit: "101" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(getResultsMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -84,4 +84,74 @@ describe("test-scenario OpenAPI contract", () => {
       ],
     ).toEqual(expect.objectContaining({ description: "Test scenario deleted" }));
   });
+
+  it("registers all five integration operations with bearer security", () => {
+    const spec = generateOpenAPISpec();
+    const paths = spec.paths ?? {};
+    const operations = [
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.post,
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.get,
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links/{specId}"]?.delete,
+      paths["/api/v2/test-scenarios/{scenarioId}/results"]?.get,
+      paths["/api/v2/test-scenarios/{scenarioId}/issues"]?.get,
+    ];
+
+    for (const operation of operations) {
+      expect(operation).toBeDefined();
+      expect(operation?.tags).toContain("Test Scenarios");
+      expect(operation?.security).toEqual([{ BearerAuth: [] }]);
+      expect(operation?.responses?.["400"]).toBeDefined();
+      expect(operation?.responses?.["401"]).toBeDefined();
+      expect(operation?.responses?.["404"]).toBeDefined();
+      expect(operation?.responses?.["500"]).toBeDefined();
+    }
+
+    expect(
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.post?.responses?.[
+        "409"
+      ],
+    ).toBeDefined();
+  });
+
+  it("documents reusable integration schemas and exact response envelopes", () => {
+    const spec = generateOpenAPISpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    expect(schemas.TestScenarioSpecLinkBody).toBeDefined();
+    expect(schemas.TestScenarioSpecLinkResponse).toBeDefined();
+    expect(schemas.TestScenarioLinkedSpec).toBeDefined();
+    expect(schemas.TestScenarioSpecLinkListResponse).toBeDefined();
+    expect(schemas.TestScenarioResultsResponse).toBeDefined();
+    expect(schemas.TestScenarioIssuesResponse).toBeDefined();
+    expect(schemas.TestScenarioEvidenceQuery).toBeDefined();
+
+    for (const name of [
+      "TestScenarioSpecLinkListResponse",
+      "TestScenarioResultsResponse",
+      "TestScenarioIssuesResponse",
+    ]) {
+      const schema = schemas[name] as { properties?: Record<string, unknown> };
+      expect(Object.keys(schema.properties ?? {})).toEqual(
+        name === "TestScenarioSpecLinkListResponse"
+          ? ["scenarioId", "projectId", "specs", "total", "page", "limit", "totalPages"]
+          : [
+              "scenarioId",
+              "projectId",
+              "linkedSpecCount",
+              name === "TestScenarioResultsResponse" ? "results" : "issues",
+              "total",
+              "page",
+              "limit",
+              "totalPages",
+            ],
+      );
+    }
+
+    const query = schemas.TestScenarioEvidenceQuery as {
+      properties?: Record<string, { maximum?: number; minimum?: number }>;
+    };
+    expect(query.properties?.page?.minimum).toBe(1);
+    expect(query.properties?.limit?.minimum).toBe(1);
+    expect(query.properties?.limit?.maximum).toBe(100);
+  });
 });

--- a/__tests__/models/testScenarioEvidenceModel.test.ts
+++ b/__tests__/models/testScenarioEvidenceModel.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+const resultFindManyMock = jest.fn<() => Promise<unknown>>();
+const resultCountMock = jest.fn<() => Promise<unknown>>();
+const issueFindManyMock = jest.fn<() => Promise<unknown>>();
+const issueCountMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    result: {
+      findMany: resultFindManyMock,
+      count: resultCountMock,
+    },
+    issue: {
+      findMany: issueFindManyMock,
+      count: issueCountMock,
+    },
+  },
+}));
+
+import { issueModel } from "@/models/issueModel";
+import { resultModel } from "@/models/resultModel";
+
+describe("scenario evidence model predicates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resultFindManyMock.mockResolvedValue([]);
+    resultCountMock.mockResolvedValue(0);
+    issueFindManyMock.mockResolvedValue([]);
+    issueCountMock.mockResolvedValue(0);
+  });
+
+  it("queries Results by database Spec IDs and both project relations", async () => {
+    await resultModel.findManyBySpecRecordIds(
+      ["spec-1", "spec-2"],
+      "project-1",
+      2,
+      5,
+    );
+    await resultModel.countBySpecRecordIds(
+      ["spec-1", "spec-2"],
+      "project-1",
+    );
+
+    expect(resultFindManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        spec: { id: { in: ["spec-1", "spec-2"] }, projectId: "project-1" },
+        execution: { projectId: "project-1" },
+      },
+      skip: 5,
+      take: 5,
+      orderBy: [{ startTime: "desc" }, { id: "desc" }],
+    }));
+    expect(resultCountMock).toHaveBeenCalledWith({
+      where: {
+        spec: { id: { in: ["spec-1", "spec-2"] }, projectId: "project-1" },
+        execution: { projectId: "project-1" },
+      },
+    });
+  });
+
+  it("queries unique Issues through Assumption to Result evidence without confirmation filtering", async () => {
+    await issueModel.findObservedBySpecRecordIds(
+      ["spec-1"],
+      "project-1",
+      1,
+      30,
+    );
+    await issueModel.countObservedBySpecRecordIds(["spec-1"], "project-1");
+
+    const expectedEvidence = {
+      projectId: "project-1",
+      assumptions: {
+        some: {
+          resultError: {
+            result: {
+              spec: { id: { in: ["spec-1"] }, projectId: "project-1" },
+              execution: { projectId: "project-1" },
+            },
+          },
+        },
+      },
+    };
+    expect(issueFindManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: expectedEvidence,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    }));
+    expect(issueCountMock).toHaveBeenCalledWith({ where: expectedEvidence });
+    const issueQuery = (issueFindManyMock.mock.calls as unknown[][])[0]?.[0];
+    expect(JSON.stringify(issueQuery)).not.toContain("isConfirmed");
+  });
+
+  it("does not query the database for empty linked Spec ID sets", async () => {
+    await expect(
+      resultModel.findManyBySpecRecordIds([], "project-1"),
+    ).resolves.toEqual([]);
+    await expect(
+      resultModel.countBySpecRecordIds([], "project-1"),
+    ).resolves.toBe(0);
+    await expect(
+      issueModel.findObservedBySpecRecordIds([], "project-1"),
+    ).resolves.toEqual([]);
+    await expect(
+      issueModel.countObservedBySpecRecordIds([], "project-1"),
+    ).resolves.toBe(0);
+
+    expect(resultFindManyMock).not.toHaveBeenCalled();
+    expect(resultCountMock).not.toHaveBeenCalled();
+    expect(issueFindManyMock).not.toHaveBeenCalled();
+    expect(issueCountMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/models/testScenarioSpecLinkModel.test.ts
+++ b/__tests__/models/testScenarioSpecLinkModel.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+const createMock = jest.fn<() => Promise<unknown>>();
+const findManyMock = jest.fn<() => Promise<unknown>>();
+const countMock = jest.fn<() => Promise<unknown>>();
+const deleteManyMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    testScenarioSpecLink: {
+      create: createMock,
+      findMany: findManyMock,
+      count: countMock,
+      deleteMany: deleteManyMock,
+    },
+  },
+}));
+
+import { testScenarioSpecLinkModel } from "@/models/testScenarioSpecLinkModel";
+
+describe("testScenarioSpecLinkModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createMock.mockResolvedValue({ testScenarioId: "scenario-1", specId: "spec-1" });
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    deleteManyMock.mockResolvedValue({ count: 1 });
+  });
+
+  it("creates one composite link and leaves duplicate enforcement to Prisma", async () => {
+    await testScenarioSpecLinkModel.create({
+      testScenarioId: "scenario-1",
+      specId: "spec-1",
+    });
+
+    expect(createMock).toHaveBeenCalledWith({
+      data: { testScenarioId: "scenario-1", specId: "spec-1" },
+    });
+  });
+
+  it("lists only same-project linked Specs with deterministic ordering", async () => {
+    await testScenarioSpecLinkModel.findLinkedSpecs(
+      "scenario-1",
+      "project-1",
+      2,
+      10,
+    );
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+      include: { spec: true },
+      skip: 10,
+      take: 10,
+      orderBy: [
+        { spec: { createdAt: "desc" } },
+        { spec: { id: "desc" } },
+      ],
+    });
+  });
+
+  it("resolves linked Spec IDs and counts through the same project predicate", async () => {
+    findManyMock.mockResolvedValueOnce([{ specId: "spec-1" }, { specId: "spec-2" }]);
+    countMock.mockResolvedValue(2);
+
+    await expect(
+      testScenarioSpecLinkModel.findLinkedSpecIds("scenario-1", "project-1"),
+    ).resolves.toEqual(["spec-1", "spec-2"]);
+    await expect(
+      testScenarioSpecLinkModel.countLinkedSpecs("scenario-1", "project-1"),
+    ).resolves.toBe(2);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+      select: { specId: true },
+    });
+    expect(countMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+    });
+  });
+
+  it("deletes only the association and reports whether it existed", async () => {
+    await expect(
+      testScenarioSpecLinkModel.delete("scenario-1", "spec-1"),
+    ).resolves.toBe(1);
+
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { testScenarioId: "scenario-1", specId: "spec-1" },
+    });
+  });
+});

--- a/__tests__/prisma/testScenarioMigration.test.ts
+++ b/__tests__/prisma/testScenarioMigration.test.ts
@@ -16,6 +16,13 @@ describe("test-scenario persistence contract", () => {
     ),
     "utf8",
   );
+  const linkMigration = readFileSync(
+    path.join(
+      process.cwd(),
+      "prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql",
+    ),
+    "utf8",
+  );
 
   it("defines a project-owned Markdown record with creator and timestamp fields", () => {
     expect(schema).toMatch(
@@ -42,5 +49,38 @@ describe("test-scenario persistence contract", () => {
     expect(migration).not.toContain('"Spec"');
     expect(migration).not.toContain('"Execution"');
     expect(migration).not.toContain('"Issue"');
+  });
+
+  it("defines a cascading unique scenario/Spec join without changing existing data", () => {
+    expect(schema).toMatch(
+      /model TestScenarioSpecLink \{[\s\S]*testScenarioId\s+String @db\.Uuid[\s\S]*specId\s+String @db\.Uuid[\s\S]*@@id\(\[testScenarioId, specId\]\)[\s\S]*@@index\(\[specId\]\)/,
+    );
+    expect(schema).toContain("specLinks TestScenarioSpecLink[]");
+    expect(schema).toContain("testScenarioLinks TestScenarioSpecLink[]");
+    expect(linkMigration).toContain('CREATE TABLE "TestScenarioSpecLink"');
+    expect(linkMigration).toContain(
+      'CONSTRAINT "TestScenarioSpecLink_pkey" PRIMARY KEY ("testScenarioId", "specId")',
+    );
+    expect(linkMigration).toContain(
+      'REFERENCES "TestScenario"("id") ON DELETE CASCADE',
+    );
+    expect(linkMigration).toContain(
+      'REFERENCES "Spec"("id") ON DELETE CASCADE',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "TestScenarioSpecLink_specId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Result_specId_startTime_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "ResultError_resultId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Assumption_issueId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Assumption_resultErrorId_idx"',
+    );
   });
 });

--- a/__tests__/routes/test-scenarios.test.ts
+++ b/__tests__/routes/test-scenarios.test.ts
@@ -5,13 +5,21 @@ import "@/test-utils/testEnv";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { jest } from "@jest/globals";
+import type { NextFunction, Request, Response } from "express";
 
-const authMiddlewareMock = jest.fn();
+const authMiddlewareMock = jest.fn<
+  (req: Request, res: Response, next: NextFunction) => void
+>();
 const controllerMocks = {
-  create: jest.fn(),
-  list: jest.fn(),
-  getById: jest.fn(),
-  delete: jest.fn(),
+  create: jest.fn<(req: Request, res: Response) => void>(),
+  list: jest.fn<(req: Request, res: Response) => void>(),
+  addSpecLink: jest.fn<(req: Request, res: Response) => void>(),
+  listSpecLinks: jest.fn<(req: Request, res: Response) => void>(),
+  removeSpecLink: jest.fn<(req: Request, res: Response) => void>(),
+  getResults: jest.fn<(req: Request, res: Response) => void>(),
+  getIssues: jest.fn<(req: Request, res: Response) => void>(),
+  getById: jest.fn<(req: Request, res: Response) => void>(),
+  delete: jest.fn<(req: Request, res: Response) => void>(),
 };
 
 jest.mock("@/middleware/authMiddleware", () => ({
@@ -41,7 +49,7 @@ describe("test-scenario routes", () => {
     jest.clearAllMocks();
   });
 
-  it("registers exactly create, list, detail, and delete operations", () => {
+  it("registers the five integration operations alongside scenario CRUD", () => {
     const routes = routeLayers()
       .filter((layer) => layer.route)
       .map((layer) => {
@@ -53,6 +61,11 @@ describe("test-scenario routes", () => {
     expect(routes).toEqual([
       "post /v2/test-scenarios",
       "get /v2/test-scenarios",
+      "post /v2/test-scenarios/:scenarioId/spec-links",
+      "get /v2/test-scenarios/:scenarioId/spec-links",
+      "delete /v2/test-scenarios/:scenarioId/spec-links/:specId",
+      "get /v2/test-scenarios/:scenarioId/results",
+      "get /v2/test-scenarios/:scenarioId/issues",
       "get /v2/test-scenarios/:scenarioId",
       "delete /v2/test-scenarios/:scenarioId",
     ]);
@@ -71,6 +84,19 @@ describe("test-scenario routes", () => {
     }
   });
 
+  it("keeps nested integration routes before the scenario detail route", () => {
+    const routes = routeLayers()
+      .filter((layer) => layer.route)
+      .map((layer) => layer.route?.path);
+    const detailIndex = routes.indexOf("/v2/test-scenarios/:scenarioId");
+    const nestedIndexes = routes
+      .map((route, index) => (route?.startsWith("/v2/test-scenarios/:scenarioId/") ? index : -1))
+      .filter((index) => index >= 0);
+
+    expect(detailIndex).toBeGreaterThan(-1);
+    expect(nestedIndexes.every((index) => index < detailIndex)).toBe(true);
+  });
+
   it("mounts the router in the central API router", () => {
     const source = readFileSync(
       path.join(process.cwd(), "src/routes/index.ts"),
@@ -83,5 +109,24 @@ describe("test-scenario routes", () => {
 
   it("does not introduce MCP operations", () => {
     expect(controllerMocks).not.toHaveProperty("mcp");
+  });
+
+  it("hands each integration route to the matching controller after auth", () => {
+    const expectedHandlers = new Map([
+      ["post /v2/test-scenarios/:scenarioId/spec-links", controllerMocks.addSpecLink],
+      ["get /v2/test-scenarios/:scenarioId/spec-links", controllerMocks.listSpecLinks],
+      ["delete /v2/test-scenarios/:scenarioId/spec-links/:specId", controllerMocks.removeSpecLink],
+      ["get /v2/test-scenarios/:scenarioId/results", controllerMocks.getResults],
+      ["get /v2/test-scenarios/:scenarioId/issues", controllerMocks.getIssues],
+    ]);
+
+    for (const [routeName, controller] of expectedHandlers) {
+      const route = routeLayers().find((layer) => {
+        const metadata = layer.route;
+        return metadata && `${Object.keys(metadata.methods)[0]} ${metadata.path}` === routeName;
+      });
+
+      expect(route?.route?.stack.some((entry) => entry.handle === controller)).toBe(true);
+    }
   });
 });

--- a/__tests__/schemas/testScenarioIntegrationSchemas.test.ts
+++ b/__tests__/schemas/testScenarioIntegrationSchemas.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  testScenarioEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema,
+  testScenarioSpecLinkListQuerySchema,
+} from "@/schemas/testScenarioIntegrationSchemas";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const specId = "22222222-2222-2222-2222-222222222222";
+
+describe("test scenario integration schemas", () => {
+  it("accepts link input and defaults paginated queries", () => {
+    expect(testScenarioSpecLinkBodySchema.parse({ specId })).toEqual({ specId });
+    expect(testScenarioSpecLinkListQuerySchema.parse({ projectId })).toEqual({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+    expect(testScenarioEvidenceQuerySchema.parse({ projectId })).toEqual({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("coerces valid pagination and rejects invalid or oversized values", () => {
+    expect(
+      testScenarioEvidenceQuerySchema.parse({
+        projectId,
+        page: "2",
+        limit: "100",
+      }),
+    ).toEqual({ projectId, page: 2, limit: 100 });
+    expect(() =>
+      testScenarioEvidenceQuerySchema.parse({ projectId, page: "0" }),
+    ).toThrow();
+    expect(() =>
+      testScenarioEvidenceQuerySchema.parse({ projectId, limit: "101" }),
+    ).toThrow();
+    expect(() =>
+      testScenarioSpecLinkBodySchema.parse({ specId: "not-a-uuid" }),
+    ).toThrow();
+  });
+});

--- a/__tests__/services/testScenarioIntegrationService.test.ts
+++ b/__tests__/services/testScenarioIntegrationService.test.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+import {
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
+
+const scenarioFindByIdMock = jest.fn<() => Promise<unknown>>();
+const specFindByIdMock = jest.fn<() => Promise<unknown>>();
+const linkCreateMock = jest.fn<() => Promise<unknown>>();
+const linkFindLinkedSpecsMock = jest.fn<() => Promise<unknown>>();
+const linkCountMock = jest.fn<() => Promise<unknown>>();
+const linkFindIdsMock = jest.fn<() => Promise<unknown>>();
+const linkDeleteMock = jest.fn<() => Promise<unknown>>();
+const resultEvidenceMock = jest.fn<() => Promise<unknown>>();
+const issueEvidenceMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: { findById: scenarioFindByIdMock },
+}));
+jest.mock("@/models/specModel", () => ({
+  specModel: { findById: specFindByIdMock },
+}));
+jest.mock("@/models/testScenarioSpecLinkModel", () => ({
+  testScenarioSpecLinkModel: {
+    create: linkCreateMock,
+    findLinkedSpecs: linkFindLinkedSpecsMock,
+    countLinkedSpecs: linkCountMock,
+    findLinkedSpecIds: linkFindIdsMock,
+    delete: linkDeleteMock,
+  },
+}));
+jest.mock("@/services/resultService", () => ({
+  resultService: { getResultsBySpecRecordIds: resultEvidenceMock },
+}));
+jest.mock("@/services/issueService", () => ({
+  issueService: { getObservedIssuesBySpecRecordIds: issueEvidenceMock },
+}));
+
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const specId = "33333333-3333-3333-3333-333333333333";
+const scenario = {
+  id: scenarioId,
+  projectId,
+  createdById: "44444444-4444-4444-4444-444444444444",
+  title: "Scenario",
+  contentMd: "# Scenario",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+const spec = {
+  id: specId,
+  projectId,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  key: "spec-1",
+  file: "login.spec.ts",
+  title: "Login",
+  tags: ["smoke"],
+  annotations: [],
+};
+
+describe("testScenarioIntegrationService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scenarioFindByIdMock.mockResolvedValue(scenario);
+    specFindByIdMock.mockResolvedValue(spec);
+    linkCreateMock.mockResolvedValue({ testScenarioId: scenarioId, specId });
+    linkFindLinkedSpecsMock.mockResolvedValue([{ spec }]);
+    linkCountMock.mockResolvedValue(1);
+    linkFindIdsMock.mockResolvedValue([specId]);
+    linkDeleteMock.mockResolvedValue(1);
+    resultEvidenceMock.mockResolvedValue({ results: [], total: 0 });
+    issueEvidenceMock.mockResolvedValue({ issues: [], total: 0 });
+  });
+
+  it("validates both endpoints in one project before creating a link", async () => {
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).resolves.toEqual({ scenarioId, specId });
+
+    expect(scenarioFindByIdMock).toHaveBeenCalledWith(scenarioId, projectId);
+    expect(specFindByIdMock).toHaveBeenCalledWith(specId, projectId);
+    expect(linkCreateMock).toHaveBeenCalledWith({
+      testScenarioId: scenarioId,
+      specId,
+    });
+  });
+
+  it("maps a database uniqueness race to the typed conflict error", async () => {
+    linkCreateMock.mockRejectedValue({ code: "P2002" });
+
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkConflictError);
+  });
+
+  it("rejects cross-project links before persistence", async () => {
+    specFindByIdMock.mockResolvedValue(null);
+
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkNotFoundError);
+    expect(linkCreateMock).not.toHaveBeenCalled();
+    expect(specFindByIdMock).toHaveBeenCalledWith(specId, projectId);
+  });
+
+  it("lists normalized Specs with stable pagination metadata", async () => {
+    const result = await testScenarioIntegrationService.listSpecLinks({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 1,
+    });
+
+    expect(result).toEqual({
+      scenarioId,
+      projectId,
+      specs: [{ ...spec, tags: ["smoke"], annotations: [] }],
+      total: 1,
+      page: 2,
+      limit: 1,
+      totalPages: 1,
+    });
+    expect(linkFindLinkedSpecsMock).toHaveBeenCalledWith(
+      scenarioId,
+      projectId,
+      2,
+      1,
+    );
+  });
+
+  it("removes only an existing link and reports missing links as not found", async () => {
+    await expect(
+      testScenarioIntegrationService.removeSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).resolves.toBeUndefined();
+    expect(linkDeleteMock).toHaveBeenCalledWith(scenarioId, specId);
+
+    linkDeleteMock.mockResolvedValue(0);
+    await expect(
+      testScenarioIntegrationService.removeSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkNotFoundError);
+  });
+
+  it("aggregates independently paginated Result evidence across linked Specs", async () => {
+    resultEvidenceMock.mockResolvedValue({ results: [{ id: "result-1" }], total: 3 });
+
+    const result = await testScenarioIntegrationService.getResults({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 2,
+    });
+
+    expect(result).toEqual({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 1,
+      results: [{ id: "result-1" }],
+      total: 3,
+      page: 2,
+      limit: 2,
+      totalPages: 2,
+    });
+    expect(resultEvidenceMock).toHaveBeenCalledWith({
+      projectId,
+      specRecordIds: [specId],
+      page: 2,
+      limit: 2,
+    });
+  });
+
+  it("returns a valid empty Issue envelope for unlinked scenarios", async () => {
+    linkFindIdsMock.mockResolvedValue([]);
+    linkCountMock.mockResolvedValue(0);
+
+    await expect(
+      testScenarioIntegrationService.getIssues({ scenarioId, projectId }),
+    ).resolves.toEqual({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      issues: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    expect(issueEvidenceMock).toHaveBeenCalledWith({
+      projectId,
+      specRecordIds: [],
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("returns 404 semantics for an unknown scenario context", async () => {
+    scenarioFindByIdMock.mockResolvedValue(null);
+
+    await expect(
+      testScenarioIntegrationService.getResults({ scenarioId, projectId }),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(linkFindIdsMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
@@ -1,0 +1,343 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+interface ScenarioRecord {
+  id: string;
+  projectId: string;
+}
+
+interface SpecRecord {
+  id: string;
+  projectId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  key: string;
+  file: string;
+  title: string;
+  tags: string[];
+  annotations: unknown[];
+}
+
+interface LinkRecord {
+  testScenarioId: string;
+  specId: string;
+}
+
+const projectA = "11111111-1111-1111-1111-111111111111";
+const scenarioA = "33333333-3333-3333-3333-333333333333";
+const scenarioB = "44444444-4444-4444-4444-444444444444";
+const specA = "55555555-5555-5555-5555-555555555555";
+const specB = "66666666-6666-6666-6666-666666666666";
+
+const scenarios: ScenarioRecord[] = [
+  { id: scenarioA, projectId: projectA },
+  { id: scenarioB, projectId: projectA },
+];
+const specs: SpecRecord[] = [
+  {
+    id: specA,
+    projectId: projectA,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    key: "spec-a",
+    file: "a.spec.ts",
+    title: "A",
+    tags: [],
+    annotations: [],
+  },
+  {
+    id: specB,
+    projectId: projectA,
+    createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    key: "spec-b",
+    file: "b.spec.ts",
+    title: "B",
+    tags: [],
+    annotations: [],
+  },
+];
+const links: LinkRecord[] = [];
+const resultEvidence = [
+  { id: "result-a", specId: specA, startTime: new Date("2026-01-01T00:00:00.000Z") },
+  { id: "result-b", specId: specB, startTime: new Date("2026-01-02T00:00:00.000Z") },
+];
+const resultErrors = [
+  { id: "error-a", resultId: "result-a" },
+  { id: "error-b", resultId: "result-b" },
+];
+const assumptions = [
+  { id: "assumption-a", resultErrorId: "error-a", issueId: "issue-shared" },
+  { id: "assumption-b", resultErrorId: "error-b", issueId: "issue-b" },
+];
+const issueEvidence = [
+  { id: "issue-shared", specIds: [specA, specB], createdAt: new Date("2026-01-01T00:00:00.000Z") },
+  { id: "issue-b", specIds: [specB], createdAt: new Date("2026-01-03T00:00:00.000Z") },
+];
+
+const scenarioFindByIdMock = jest.fn<
+  (id: string, projectId: string) => Promise<ScenarioRecord | null>
+>();
+const scenarioDeleteMock = jest.fn<
+  (id: string, projectId: string) => Promise<number>
+>();
+const specFindByIdMock = jest.fn<
+  (id: string, projectId: string) => Promise<SpecRecord | null>
+>();
+const specDeleteMock = jest.fn<(id: string, projectId: string) => Promise<void>>();
+const linkCreateMock = jest.fn<
+  (data: LinkRecord) => Promise<LinkRecord>
+>();
+const linkFindSpecsMock = jest.fn<
+  (scenarioId: string, projectId: string, page?: number, limit?: number) =>
+    Promise<Array<{ spec: SpecRecord }>>
+>();
+const linkCountMock = jest.fn<
+  (scenarioId: string, projectId: string) => Promise<number>
+>();
+const linkFindIdsMock = jest.fn<
+  (scenarioId: string, projectId: string) => Promise<string[]>
+>();
+const linkDeleteMock = jest.fn<
+  (scenarioId: string, specId: string) => Promise<number>
+>();
+const resultEvidenceMock = jest.fn<
+  (params: {
+    projectId: string;
+    specRecordIds: string[];
+    page: number;
+    limit: number;
+  }) => Promise<{ results: Array<{ id: string; specId: string; startTime: Date }>; total: number }>
+>();
+const issueEvidenceMock = jest.fn<
+  (params: {
+    projectId: string;
+    specRecordIds: string[];
+    page: number;
+    limit: number;
+  }) => Promise<{ issues: Array<{ id: string; specIds: string[]; createdAt: Date }>; total: number }>
+>();
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    findById: scenarioFindByIdMock,
+    delete: scenarioDeleteMock,
+  },
+}));
+jest.mock("@/models/specModel", () => ({
+  specModel: {
+    findById: specFindByIdMock,
+    delete: specDeleteMock,
+  },
+}));
+jest.mock("@/models/testScenarioSpecLinkModel", () => ({
+  testScenarioSpecLinkModel: {
+    create: linkCreateMock,
+    findLinkedSpecs: linkFindSpecsMock,
+    countLinkedSpecs: linkCountMock,
+    findLinkedSpecIds: linkFindIdsMock,
+    delete: linkDeleteMock,
+  },
+}));
+jest.mock("@/services/resultService", () => ({
+  resultService: { getResultsBySpecRecordIds: resultEvidenceMock },
+}));
+jest.mock("@/services/issueService", () => ({
+  issueService: { getObservedIssuesBySpecRecordIds: issueEvidenceMock },
+}));
+
+import { specService } from "@/services/specService";
+import { testScenarioService } from "@/services/testScenarioService";
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
+
+describe("test scenario execution evidence workflow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    links.length = 0;
+    if (!scenarios.some((scenario) => scenario.id === scenarioA)) {
+      scenarios.push({ id: scenarioA, projectId: projectA });
+    }
+    if (!scenarios.some((scenario) => scenario.id === scenarioB)) {
+      scenarios.push({ id: scenarioB, projectId: projectA });
+    }
+    if (!specs.some((spec) => spec.id === specA)) {
+      specs.push({
+        id: specA,
+        projectId: projectA,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        key: "spec-a",
+        file: "a.spec.ts",
+        title: "A",
+        tags: [],
+        annotations: [],
+      });
+    }
+    if (!specs.some((spec) => spec.id === specB)) {
+      specs.push({
+        id: specB,
+        projectId: projectA,
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        key: "spec-b",
+        file: "b.spec.ts",
+        title: "B",
+        tags: [],
+        annotations: [],
+      });
+    }
+    scenarios.sort((left, right) => left.id.localeCompare(right.id));
+    specs.sort((left, right) => left.id.localeCompare(right.id));
+    scenarioFindByIdMock.mockImplementation(async (id, projectId) =>
+      scenarios.find((scenario) => scenario.id === id && scenario.projectId === projectId) ?? null,
+    );
+    scenarioDeleteMock.mockImplementation(async (id, projectId) => {
+      const index = scenarios.findIndex(
+        (scenario) => scenario.id === id && scenario.projectId === projectId,
+      );
+      if (index === -1) return 0;
+      scenarios.splice(index, 1);
+      links.splice(0, links.length, ...links.filter((link) => link.testScenarioId !== id));
+      return 1;
+    });
+    specFindByIdMock.mockImplementation(async (id, projectId) =>
+      specs.find((spec) => spec.id === id && spec.projectId === projectId) ?? null,
+    );
+    specDeleteMock.mockImplementation(async (id, projectId) => {
+      const index = specs.findIndex(
+        (spec) => spec.id === id && spec.projectId === projectId,
+      );
+      if (index === -1) throw new Error(`Spec with ID ${id} not found`);
+      specs.splice(index, 1);
+      links.splice(0, links.length, ...links.filter((link) => link.specId !== id));
+    });
+    linkCreateMock.mockImplementation(async (data) => {
+      if (links.some((link) => link.testScenarioId === data.testScenarioId && link.specId === data.specId)) {
+        throw { code: "P2002" } as unknown;
+      }
+      links.push(data);
+      return data;
+    });
+    linkFindSpecsMock.mockImplementation(async (scenarioId: string, projectId: string, page = 1, limit = 30) => {
+      const matching = links
+        .filter((link) => link.testScenarioId === scenarioId)
+        .map((link) => ({ spec: specs.find((spec) => spec.id === link.specId) }))
+        .filter((link): link is { spec: SpecRecord } => link.spec?.projectId === projectId)
+        .sort((left, right) => right.spec.createdAt.getTime() - left.spec.createdAt.getTime());
+      return matching.slice((page - 1) * limit, page * limit);
+    });
+    linkCountMock.mockImplementation(async (scenarioId: string, projectId: string) =>
+      links.filter((link) => link.testScenarioId === scenarioId && specs.some((spec) => spec.id === link.specId && spec.projectId === projectId)).length,
+    );
+    linkFindIdsMock.mockImplementation(async (scenarioId: string, projectId: string) =>
+      links
+        .filter((link) => link.testScenarioId === scenarioId && specs.some((spec) => spec.id === link.specId && spec.projectId === projectId))
+        .map((link) => link.specId),
+    );
+    linkDeleteMock.mockImplementation(async (scenarioId: string, specId: string) => {
+      const index = links.findIndex((link) => link.testScenarioId === scenarioId && link.specId === specId);
+      if (index === -1) return 0;
+      links.splice(index, 1);
+      return 1;
+    });
+    resultEvidenceMock.mockImplementation(async ({ projectId, specRecordIds, page, limit }: { projectId: string; specRecordIds: string[]; page: number; limit: number }) => {
+      const matching = resultEvidence.filter((result) => specRecordIds.includes(result.specId) && specs.some((spec) => spec.id === result.specId && spec.projectId === projectId));
+      const sorted = [...matching].sort((left, right) => right.startTime.getTime() - left.startTime.getTime() || right.id.localeCompare(left.id));
+      return { results: sorted.slice((page - 1) * limit, page * limit), total: sorted.length };
+    });
+    issueEvidenceMock.mockImplementation(async ({ projectId, specRecordIds, page, limit }: { projectId: string; specRecordIds: string[]; page: number; limit: number }) => {
+      const matching = issueEvidence.filter((issue) => issue.specIds.some((id) => specRecordIds.includes(id)) && specs.some((spec) => issue.specIds.includes(spec.id) && spec.projectId === projectId));
+      const unique = [...new Map(matching.map((issue) => [issue.id, issue])).values()]
+        .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime() || right.id.localeCompare(left.id));
+      return { issues: unique.slice((page - 1) * limit, page * limit), total: unique.length };
+    });
+  });
+
+  it("links multiple scenarios and Specs with independent Result and Issue pagination", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specB, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioB, specId: specB, projectId: projectA });
+
+    const resultPageOne = await testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA, page: 1, limit: 1 });
+    const resultPageTwo = await testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA, page: 2, limit: 1 });
+    const issuePageOne = await testScenarioIntegrationService.getIssues({ scenarioId: scenarioA, projectId: projectA, page: 1, limit: 1 });
+    const issuePageTwo = await testScenarioIntegrationService.getIssues({ scenarioId: scenarioA, projectId: projectA, page: 2, limit: 1 });
+
+    expect(resultPageOne.linkedSpecCount).toBe(2);
+    expect(resultPageOne.total).toBe(2);
+    expect(resultPageOne.results[0]?.id).toBe("result-b");
+    expect(resultPageTwo.results[0]?.id).toBe("result-a");
+    expect(issuePageOne.total).toBe(2);
+    expect(issuePageOne.issues[0]?.id).toBe("issue-b");
+    expect(issuePageTwo.issues[0]?.id).toBe("issue-shared");
+
+    const scenarioBResults = await testScenarioIntegrationService.getResults({ scenarioId: scenarioB, projectId: projectA });
+    expect(scenarioBResults.linkedSpecCount).toBe(1);
+    expect(scenarioBResults.results.map((result) => result.id)).toEqual(["result-b"]);
+  });
+
+  it("unlinks only the association and preserves endpoints and evidence", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specB, projectId: projectA });
+    const endpointSnapshot = {
+      scenarios: scenarios.map((scenario) => ({ ...scenario })),
+      specs: specs.map((spec) => ({ ...spec })),
+      results: resultEvidence.map((result) => ({ ...result })),
+      resultErrors: resultErrors.map((error) => ({ ...error })),
+      assumptions: assumptions.map((assumption) => ({ ...assumption })),
+      issues: issueEvidence.map((issue) => ({ ...issue })),
+    };
+
+    await testScenarioIntegrationService.removeSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+
+    expect(scenarios).toEqual(endpointSnapshot.scenarios);
+    expect(specs).toEqual(endpointSnapshot.specs);
+    expect(resultEvidence).toEqual(endpointSnapshot.results);
+    expect(resultErrors).toEqual(endpointSnapshot.resultErrors);
+    expect(assumptions).toEqual(endpointSnapshot.assumptions);
+    expect(issueEvidence).toEqual(endpointSnapshot.issues);
+    await expect(testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA })).resolves.toEqual(expect.objectContaining({ linkedSpecCount: 1, total: 1 }));
+  });
+
+  it("removes scenario links while preserving Specs and evidence on scenario deletion", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    const specsSnapshot = specs.map((spec) => ({ ...spec }));
+    const evidenceSnapshot = resultEvidence.map((result) => ({ ...result }));
+    const resultErrorsSnapshot = resultErrors.map((error) => ({ ...error }));
+    const assumptionsSnapshot = assumptions.map((assumption) => ({ ...assumption }));
+
+    await testScenarioService.deleteScenario(scenarioA, projectA);
+
+    expect(scenarios.some((scenario) => scenario.id === scenarioA)).toBe(false);
+    expect(links).toEqual([]);
+    expect(specs).toEqual(specsSnapshot);
+    expect(resultEvidence).toEqual(evidenceSnapshot);
+    expect(resultErrors).toEqual(resultErrorsSnapshot);
+    expect(assumptions).toEqual(assumptionsSnapshot);
+  });
+
+  it("removes Spec links while preserving linked scenarios on Spec deletion", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioB, specId: specB, projectId: projectA });
+
+    await specService.deleteSpec(specA, projectA);
+
+    expect(scenarios).toEqual([
+      { id: scenarioA, projectId: projectA },
+      { id: scenarioB, projectId: projectA },
+    ]);
+    expect(links).toEqual([{ testScenarioId: scenarioB, specId: specB }]);
+    expect(resultEvidence).toHaveLength(2);
+    expect(resultErrors).toHaveLength(2);
+    expect(assumptions).toHaveLength(2);
+    expect(issueEvidence).toHaveLength(2);
+  });
+});

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/.openspec.yaml
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/design.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/design.md
@@ -1,0 +1,141 @@
+## Context
+
+The completed Markdown Test Scenario slice provides authenticated project-scoped CRUD for authored scenarios. Automated execution evidence remains owned by the existing graph `Spec → Result → ResultError → Assumption → Issue`. Issue #73 must connect those domains without copying ownership, mutating imported data, or creating direct scenario links to individual Results or Issues.
+
+Coverage is many-to-many: one authored scenario can be exercised by several Specs, and one Spec can support several scenarios. Links are strictly local to one project. Existing Result filters distinguish a Spec business key from a database Spec record ID, and existing Issue list queries do not yet express the complete scenario evidence traversal, so reusable service-level query entry points are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist unique, project-local many-to-many scenario/Spec links.
+- Provide authenticated add, paginated list, and remove operations for links.
+- Aggregate deterministic, paginated Result history across all linked Specs.
+- Derive deterministic, paginated, deduplicated observed Issues from existing Assumptions.
+- Distinguish unlinked scenarios from linked scenarios that have no evidence.
+- Preserve both endpoint records and all evidence when a link is removed.
+- Keep orchestration reusable by REST and future MCP handlers.
+
+**Non-Goals:**
+
+- Cross-project links or reads.
+- Direct scenario links to Results or Issues.
+- Automatic matching by title, file, key, or report ingestion.
+- Link notes, weights, coverage types, scoring, or audit metadata.
+- Rendering scenario integration in a client or exposing MCP tools.
+- Changing confirmation semantics or ownership of Assumptions and Issues.
+
+## Decisions
+
+### 1. Use an explicit join model
+
+Add `TestScenarioSpecLink` with `testScenarioId` and `specId` as a composite primary key. Add relation collections to `TestScenario` and `Spec`, and an index beginning with `specId` for reverse lookup. Both foreign keys use `onDelete: Cascade` because the join row has no independent lifecycle: deleting either endpoint removes only its links.
+
+An explicit join model is preferred over a nullable foreign key because the relationship is many-to-many. It is preferred over Prisma's implicit many-to-many relation because a named model makes constraints, migrations, model ownership, and future extension explicit. No link metadata is added in this issue.
+
+The link table does not store `projectId`. The service proves project locality by loading both endpoints with the same requested `projectId` before insertion. Project IDs are immutable in current behavior, so this does not create a later drift path. Adding redundant project columns and composite foreign keys was rejected as disproportionate complexity.
+
+### 2. Expose resource-oriented link operations
+
+Add these authenticated routes:
+
+- `POST /api/v2/test-scenarios/{scenarioId}/spec-links?projectId=...` with `{ "specId": "uuid" }`.
+- `GET /api/v2/test-scenarios/{scenarioId}/spec-links?projectId=...&page=1&limit=30`.
+- `DELETE /api/v2/test-scenarios/{scenarioId}/spec-links/{specId}?projectId=...`.
+
+Creation returns HTTP 201 with `{ scenarioId, specId }`. The composite primary key is the final race-safe duplicate guard; a Prisma unique violation maps to HTTP 409. Removing an existing link returns an empty HTTP 204 response. An absent link or a scenario/Spec outside the requested project context returns HTTP 404, consistent with existing scenario identity protection.
+
+A single PATCH that replaces a `specId` was rejected because it encodes one-to-one cardinality and makes multi-link additions/removals less explicit.
+
+### 3. Return paginated linked Specs
+
+The linked-Spec response is:
+
+```json
+{
+  "scenarioId": "uuid",
+  "projectId": "uuid",
+  "specs": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+It reuses the normalized public Spec representation and orders Specs by `createdAt DESC, id DESC`. Page defaults to 1, limit defaults to 30, and limit is capped at 100, matching the scenario API.
+
+### 4. Aggregate Results by Spec record IDs
+
+Add `GET /api/v2/test-scenarios/{scenarioId}/results?projectId=...&page=1&limit=30` with this envelope:
+
+```json
+{
+  "scenarioId": "uuid",
+  "projectId": "uuid",
+  "linkedSpecCount": 0,
+  "results": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+The query unions Results whose database `specId` belongs to any linked Spec, returns each Result once, applies the existing normalized public Result representation, and orders by `startTime DESC, id DESC`. It also retains the existing defense-in-depth requirement that both the Result's Spec and Execution belong to the requested project.
+
+Expose a reusable Result service method explicitly named for Spec record IDs rather than overloading the existing public `specId` filter, which currently means the Spec business key. Returning `linkedSpecCount` lets consumers distinguish an unlinked scenario from linked Specs with no Results without embedding an unbounded Spec-ID list.
+
+### 5. Query observed Issues directly and deduplicate by identity
+
+Add `GET /api/v2/test-scenarios/{scenarioId}/issues?projectId=...&page=1&limit=30` using the same envelope, with `issues` replacing `results`. The Issue predicate traverses:
+
+```text
+Issue.assumptions
+  → ResultError
+  → Result
+  → linked Spec IDs
+```
+
+Every Issue reached through an Assumption is observed regardless of `isConfirmed`. Querying Issue records directly naturally returns one row per Issue even if several errors, assumptions, Results, or linked Specs reach it. Results are ordered by `createdAt DESC, id DESC` and use the existing normalized public Issue representation.
+
+A flattened join followed by application-level deduplication was rejected because it inflates intermediate rows and makes count/pagination incorrect. A direct Scenario-to-Issue relation was rejected because it would duplicate evidence ownership and lose provenance.
+
+### 6. Centralize integration orchestration in services
+
+Add a `testScenarioIntegrationService` that validates scenario context, resolves linked Spec IDs/counts, and coordinates reusable Result and Issue service methods. A dedicated link model owns join persistence and paginated Spec reads. Controllers validate transport input and map typed validation, not-found, and conflict errors; they do not build Prisma predicates.
+
+This keeps REST thin and gives future MCP handlers a service API. Calling Result/Issue models directly from controllers or duplicating evidence traversal in handlers was rejected.
+
+### 7. Use consistent pagination and error contracts
+
+All three list/read endpoints accept positive integer `page` and `limit`, with defaults 1 and 30 and maximum limit 100. Counts and item queries use identical link, project, and evidence predicates. Invalid input returns 400, missing authentication returns 401, project-context misses return 404, duplicate links return 409, and unexpected failures return 500, all using `{ "error": string }`.
+
+An unlinked scenario is still a valid resource and returns HTTP 200 with `linkedSpecCount: 0`, an empty collection, and zero totals. An unknown scenario returns 404.
+
+### 8. Add indexes for the evidence traversal
+
+In addition to the composite link primary key and reverse Spec index, add or confirm supporting indexes for Result lookup by Spec/time and the ResultError/Assumption foreign-key traversal used by observed-Issue queries. Index definitions must follow actual Prisma query predicates and be reviewed against existing indexes to avoid duplication.
+
+This adds some migration/write overhead but prevents evidence reads from degenerating into repeated full scans as execution history grows.
+
+## Risks / Trade-offs
+
+- **[Risk] Evidence queries can traverse large histories.** → Require bounded pagination, count with the same predicate, and add supporting foreign-key/query indexes.
+- **[Risk] Duplicate link checks race under concurrent requests.** → Enforce the composite primary key in PostgreSQL and map the unique violation to 409.
+- **[Risk] Cross-project links could be created by trusting IDs independently.** → Resolve both scenario and Spec through the same `projectId` before inserting and cover cross-project attempts in model/service/route tests.
+- **[Risk] The same Issue may appear through many evidence paths.** → Query distinct Issue entities directly so count and pagination operate on Issue identity.
+- **[Risk] A Spec key may change and ingestion may create a new Spec record.** → Keep automatic reconciliation out of scope; links intentionally target stable database Spec records.
+- **[Trade-off] Offset pagination can shift as new Results arrive.** → Use deterministic secondary ordering now; cursor pagination can be introduced later without changing relation storage.
+- **[Trade-off] Cascade deletion removes links when a Spec is deleted.** → Preserve scenarios while retaining the repository's existing Spec-deletion semantics for execution data.
+
+## Migration Plan
+
+1. Add the join model, endpoint relations, composite primary key, reverse index, and reviewed evidence-query indexes in an additive Prisma migration.
+2. Generate Prisma client types and deploy the migration before or with application code that accesses the new table.
+3. No backfill is required; existing scenarios begin with zero links and therefore return empty evidence collections.
+4. Rollback application routes before dropping the join table and newly introduced nonessential indexes. Dropping the link table removes associations only and does not modify scenarios or execution history.
+
+## Open Questions
+
+None for issue #73. Automatic Spec reconciliation, selected-Result evidence, confirmation-only Issue views, link metadata, and coverage scoring remain separate product decisions.

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/proposal.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Managed Test Scenarios are currently isolated from automated execution evidence, so consumers cannot determine which Results or Issues demonstrate a scenario's behavior. This change connects authored scenarios to project-local automated Specs while retaining the existing Spec-owned execution graph as the source of truth.
+
+## What Changes
+
+- Add an explicit project-local many-to-many association between `TestScenario` and `Spec`.
+- Allow authenticated clients to add, list, and remove scenario/Spec links through REST operations.
+- Enforce uniqueness for each scenario/Spec pair and reject cross-project links.
+- Expose independently paginated Results aggregated across every Spec linked to a scenario.
+- Expose independently paginated, deduplicated Issues derived through linked Specs, Results, ResultErrors, and Assumptions.
+- Treat Issues reached through any existing Assumption as observed, regardless of confirmation state.
+- Return stable empty integration responses when a scenario has no linked Specs or no execution evidence.
+- Preserve Test Scenarios, Specs, Results, ResultErrors, Assumptions, and Issues when individual links are removed.
+- Remove only scenario link rows when a Test Scenario is deleted, preserving the existing execution and issue graph.
+- Keep direct Scenario-to-Result and Scenario-to-Issue links, automatic matching, coverage scoring, link metadata, UI, and MCP tools out of scope.
+- Document link-management and evidence-query contracts in OpenAPI and add migration and regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-scenario-execution-evidence`: Defines project-local many-to-many scenario/Spec links, authenticated link management, aggregated Result history, and derived observed-Issue queries.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Prisma schema, generated client, migration history, and scenario/Spec relation deletion behavior.
+- Test-scenario schemas, types, models, services, controllers, and routes.
+- Result and Issue model/service query paths reused or extended for Spec-record aggregation and evidence derivation.
+- OpenAPI component schemas, route registration, and contract tests.
+- Link-model, integration-service, controller, route, aggregation, deduplication, project-isolation, and deletion-safety tests.
+- Depends on the completed `add-markdown-test-scenarios` change and GitHub issue #72.
+- GitHub tracking issue: https://github.com/VENTIONINC/TestPortal-backend/issues/73

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/specs/test-scenario-execution-evidence/spec.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/specs/test-scenario-execution-evidence/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: Test Scenarios and Specs have project-local many-to-many links
+The system SHALL represent Test Scenario coverage through an explicit many-to-many link between `TestScenario` and `Spec`. A scenario MAY link to multiple Specs, a Spec MAY link to multiple scenarios, and each `(testScenarioId, specId)` pair SHALL be unique. Both endpoints of every link SHALL belong to the requested project.
+
+#### Scenario: Scenario links to several Specs
+- **WHEN** an authenticated client links one scenario to multiple Specs in the same project
+- **THEN** the system stores one unique link for each scenario/Spec pair
+- **AND** all linked Specs remain independently owned execution records
+
+#### Scenario: Spec links to several scenarios
+- **WHEN** an authenticated client links one Spec to multiple scenarios in the same project
+- **THEN** the system stores each unique scenario/Spec pair
+- **AND** no existing scenario link for that Spec is replaced
+
+#### Scenario: Cross-project link is rejected
+- **WHEN** the scenario and target Spec do not both belong to the requested project
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no link is created
+
+### Requirement: Authenticated clients can add Spec links
+The system SHALL expose `POST /api/v2/test-scenarios/{scenarioId}/spec-links` to authenticated clients. The endpoint SHALL require a valid `projectId` query parameter and valid `specId` body field, and SHALL return HTTP 201 with the stored scenario and Spec identifiers.
+
+#### Scenario: Add a new Spec link
+- **WHEN** an authenticated client submits a same-project scenario ID and Spec ID that are not already linked
+- **THEN** the system returns HTTP 201 with `{ "scenarioId": string, "specId": string }`
+- **AND** the association becomes available to linked-Spec and evidence queries
+
+#### Scenario: Duplicate link is rejected
+- **WHEN** an authenticated client submits a scenario/Spec pair that already exists
+- **THEN** the system returns HTTP 409 with an `{ "error": string }` response
+- **AND** exactly one copy of the link remains stored
+
+#### Scenario: Add-link input is invalid
+- **WHEN** the scenario ID, project ID, or Spec ID is missing or malformed
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** no link is created
+
+### Requirement: Authenticated clients can list linked Specs
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/spec-links` to authenticated clients. It SHALL return a project-scoped, deterministically ordered page containing normalized Spec representations and exactly the top-level fields `scenarioId`, `projectId`, `specs`, `total`, `page`, `limit`, and `totalPages`.
+
+#### Scenario: List linked Specs
+- **WHEN** an authenticated client requests links for an existing scenario in the requested project
+- **THEN** the system returns only Specs linked to that scenario and belonging to that project
+- **AND** orders them by creation time descending and then ID descending
+
+#### Scenario: Scenario has no linked Specs
+- **WHEN** an authenticated client lists Spec links for an existing unlinked scenario
+- **THEN** the system returns HTTP 200 with an empty `specs` array and zero pagination totals
+
+### Requirement: Authenticated clients can remove Spec links safely
+The system SHALL expose `DELETE /api/v2/test-scenarios/{scenarioId}/spec-links/{specId}` to authenticated clients and SHALL require a valid `projectId` query parameter. Removing a link SHALL return an empty HTTP 204 response and SHALL NOT delete or modify either endpoint or any execution or issue record.
+
+#### Scenario: Remove an existing link
+- **WHEN** an authenticated client removes an existing same-project scenario/Spec link
+- **THEN** the system returns HTTP 204 with no response body
+- **AND** removes only that link row
+
+#### Scenario: Link does not exist in the requested context
+- **WHEN** the requested pair is absent or is not valid in the requested project context
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no scenario, Spec, Result, ResultError, Assumption, or Issue is modified
+
+### Requirement: Scenario Result history is aggregated across linked Specs
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/results` to authenticated clients. It SHALL return each Result whose database Spec record is linked to the scenario and whose Spec and Execution belong to the requested project. Each Result SHALL appear at most once and SHALL use the normalized public Result representation.
+
+#### Scenario: Results from multiple linked Specs are returned
+- **WHEN** an authenticated client requests Results for a scenario linked to several Specs with execution history
+- **THEN** the system returns only Results belonging to those linked Specs in the requested project
+- **AND** orders them by start time descending and then ID descending
+
+#### Scenario: Unlinked scenario has empty Result history
+- **WHEN** an authenticated client requests Results for an existing scenario with no linked Specs
+- **THEN** the system returns HTTP 200 with `linkedSpecCount` equal to 0, an empty `results` array, and zero pagination totals
+
+#### Scenario: Linked Specs have no Results
+- **WHEN** an authenticated client requests Results for a scenario with linked Specs that have no Results
+- **THEN** the system returns HTTP 200 with a positive `linkedSpecCount`, an empty `results` array, and zero pagination totals
+
+### Requirement: Observed Issues are derived and deduplicated
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/issues` to authenticated clients. It SHALL derive Issues only through linked Specs, their Results, ResultErrors, and Assumptions. Every Issue reached through an Assumption SHALL be considered observed regardless of confirmation state, and each Issue SHALL appear at most once using the normalized public Issue representation.
+
+#### Scenario: Issues are derived through execution evidence
+- **WHEN** linked-Spec Results have ResultErrors whose Assumptions reference Issues
+- **THEN** the system returns those Issues without creating a direct scenario/Issue association
+
+#### Scenario: Issue reached through several paths is deduplicated
+- **WHEN** one Issue is referenced by multiple Assumptions, errors, Results, or linked Specs for the scenario
+- **THEN** the Issue appears once in the response
+- **AND** contributes one to the total count
+
+#### Scenario: Unconfirmed assumption contributes an observed Issue
+- **WHEN** an Issue is reached through an Assumption whose `isConfirmed` value is false
+- **THEN** the Issue is included in the observed-Issue response
+
+#### Scenario: Scenario has no observed Issues
+- **WHEN** a scenario is unlinked or none of its linked-Spec evidence reaches an Issue
+- **THEN** the system returns HTTP 200 with an empty `issues` array and zero pagination totals
+
+### Requirement: Evidence responses are independently and deterministically paginated
+The Result and Issue endpoints SHALL accept positive integer `page` and `limit` parameters, default page to 1, default limit to 30, and reject limits greater than 100. Each response SHALL contain exactly `scenarioId`, `projectId`, `linkedSpecCount`, its domain collection, `total`, `page`, `limit`, and `totalPages` as top-level fields. Item and count queries SHALL use the same project, link, and evidence predicates.
+
+#### Scenario: Explicit Result page is returned
+- **WHEN** an authenticated client requests a valid Result page and limit
+- **THEN** the system returns the corresponding deterministic Result slice
+- **AND** pagination totals describe all matching linked-Spec Results
+
+#### Scenario: Explicit Issue page is returned
+- **WHEN** an authenticated client requests a valid Issue page and limit
+- **THEN** the system returns the corresponding deterministic unique-Issue slice
+- **AND** pagination totals describe all matching observed Issues
+
+#### Scenario: Evidence pagination is invalid
+- **WHEN** page or limit is non-numeric, fractional, zero, negative, or limit exceeds 100
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Link lifecycle does not own scenarios or execution evidence
+Removing a link SHALL remove only the association. Deleting a Test Scenario SHALL remove its link rows and the scenario while preserving linked Specs and all Results, ResultErrors, Assumptions, and Issues. Deleting a Spec through existing behavior SHALL remove its link rows and leave linked Test Scenarios intact.
+
+#### Scenario: Removing a link preserves all domain records
+- **WHEN** an authenticated client removes a scenario/Spec link with existing execution and issue evidence
+- **THEN** the scenario, Spec, Results, ResultErrors, Assumptions, and Issues remain unchanged
+
+#### Scenario: Deleting a linked scenario preserves evidence
+- **WHEN** an authenticated client deletes a Test Scenario that has one or more Spec links
+- **THEN** the system removes the scenario and its link rows
+- **AND** preserves every linked Spec, Result, ResultError, Assumption, and Issue
+
+#### Scenario: Deleting a linked Spec preserves scenarios
+- **WHEN** the existing Spec deletion behavior deletes a Spec linked to one or more scenarios
+- **THEN** the system removes the Spec link rows
+- **AND** preserves every linked Test Scenario
+
+### Requirement: Integration APIs require authentication and documented contracts
+All Spec-link and evidence routes SHALL use the existing JWT authentication middleware. OpenAPI SHALL document link and evidence request schemas, stable success envelopes, pagination constraints, bearer authentication, and applicable 400, 401, 404, 409, and 500 error responses using the common error schema. Integration orchestration SHALL be available through services reusable by REST and future MCP handlers.
+
+#### Scenario: Integration request is unauthenticated
+- **WHEN** a client calls any Spec-link or evidence route without a valid authentication token
+- **THEN** the system returns HTTP 401 with an `{ "error": string }` response
+- **AND** no link or evidence data is returned or mutated
+
+#### Scenario: OpenAPI document is generated
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** all five integration operations and their request and response schemas are present under the Test Scenarios tag

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/tasks.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/tasks.md
@@ -1,0 +1,59 @@
+## 1. Persistence and Migration
+
+- [x] 1.1 Add the explicit `TestScenarioSpecLink` Prisma model, endpoint relations, composite primary key, cascading link foreign keys, and reverse Spec index.
+- [x] 1.2 Inspect existing Result, ResultError, and Assumption indexes against the planned evidence predicates and add only the missing supporting indexes.
+- [x] 1.3 Create and review the additive Prisma migration, including rollback implications and confirmation that it does not alter existing scenario or evidence rows.
+- [x] 1.4 Regenerate the Prisma client and add migration/schema regression coverage for link uniqueness, foreign keys, cascade behavior, and evidence indexes.
+
+## 2. Integration Contracts and Validation
+
+- [x] 2.1 Create header-compliant integration type/schema files with the repository new-file workflow and export them through the established type surface.
+- [x] 2.2 Define Zod schemas for scenario/spec identifiers, add-link input, project context, and defaulted page/limit queries capped at 100.
+- [x] 2.3 Define typed link, linked-Spec list, scenario-Result, and observed-Issue response envelopes with exact stable top-level fields.
+- [x] 2.4 Add a typed duplicate-link conflict error and extend controller error mapping without relying on message-string inspection.
+
+## 3. Link Model and Link Management Service
+
+- [x] 3.1 Implement link-model creation with database-enforced composite uniqueness and Prisma conflict translation support.
+- [x] 3.2 Implement project-scoped deterministic linked-Spec list/count queries and linked Spec-ID/count resolution helpers.
+- [x] 3.3 Implement composite link deletion that reports whether an association existed without deleting either endpoint.
+- [x] 3.4 Implement service-level add-link validation that resolves both scenario and Spec through the same requested project before insertion.
+- [x] 3.5 Implement paginated linked-Spec listing and safe remove-link behavior with typed not-found and conflict outcomes.
+- [x] 3.6 Add model and service tests for many-to-many cardinality, duplicate races, cross-project rejection, pagination, and isolated unlinking.
+
+## 4. Reusable Result and Issue Evidence Queries
+
+- [x] 4.1 Add a Result service/model entry point explicitly filtering by database Spec record IDs, requested project, and deterministic `startTime DESC, id DESC` ordering.
+- [x] 4.2 Ensure the Result evidence item/count predicates match, return normalized public Results, and enforce both Spec and Execution project scope.
+- [x] 4.3 Add an Issue service/model entry point that traverses Assumption → ResultError → Result for linked Spec record IDs and the requested project.
+- [x] 4.4 Ensure observed-Issue item/count queries return unique normalized Issues, include confirmed and unconfirmed Assumptions, and order by `createdAt DESC, id DESC`.
+- [x] 4.5 Add Result and Issue query tests for multiple Spec IDs, empty ID sets, project isolation, deterministic pagination, deduplication, and confirmation-independent observation.
+
+## 5. Scenario Integration Service and REST Routes
+
+- [x] 5.1 Implement `testScenarioIntegrationService` orchestration for linked Specs, aggregated Results, observed Issues, linked-Spec counts, and valid empty responses.
+- [x] 5.2 Implement controller handlers for add/list/remove links and Result/Issue evidence reads with shared validation and consistent status/error envelopes.
+- [x] 5.3 Register the five authenticated nested Test Scenario routes in the existing test-scenario router with safe ordering relative to `/:scenarioId`.
+- [x] 5.4 Add controller tests for request validation, response shapes, empty evidence states, 201/200/204 success behavior, and 400/404/409/500 mapping.
+- [x] 5.5 Add route tests for JWT protection, parameter/query/body handoff, duplicate conflicts, and cross-project rejection across all five operations.
+
+## 6. OpenAPI Contract
+
+- [x] 6.1 Add or reuse OpenAPI schemas for link input/output, normalized Specs, normalized Results, normalized Issues, and the three paginated integration envelopes.
+- [x] 6.2 Register all five operations with bearer security, pagination constraints, exact response shapes, and common 400/401/404/409/500 error contracts as applicable.
+- [x] 6.3 Add OpenAPI contract tests for operation presence, schema reuse, required context fields, limits, error documentation, and Test Scenarios tagging.
+
+## 7. Lifecycle and Workflow Regression Coverage
+
+- [x] 7.1 Add an integration workflow covering multiple scenarios linked to multiple Specs and independently paginated Result and Issue reads.
+- [x] 7.2 Add regression coverage proving link removal preserves both endpoints and all Results, ResultErrors, Assumptions, and Issues.
+- [x] 7.3 Extend scenario-deletion coverage to prove link rows are removed while Specs and all evidence remain unchanged.
+- [x] 7.4 Add Spec-deletion coverage proving link rows are removed and linked Test Scenarios survive under existing Spec deletion semantics.
+- [x] 7.5 Run focused MVC-boundary, Prisma-migration, OpenAPI-contract, and Jest-pattern reviews and resolve identified drift.
+
+## 8. Verification
+
+- [x] 8.1 Run `npm run type-check` and resolve all strict TypeScript errors.
+- [x] 8.2 Run `npm run lint` and resolve all ESLint or license-header violations.
+- [x] 8.3 Run `npm test` and confirm the complete Jest suite passes.
+- [x] 8.4 Run `npm run build` and confirm the production build succeeds.

--- a/prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql
+++ b/prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql
@@ -1,0 +1,22 @@
+-- Additive scenario/Spec association only. Existing scenarios and evidence are untouched.
+CREATE TABLE "TestScenarioSpecLink" (
+    "testScenarioId" UUID NOT NULL,
+    "specId" UUID NOT NULL,
+
+    CONSTRAINT "TestScenarioSpecLink_pkey" PRIMARY KEY ("testScenarioId", "specId")
+);
+
+CREATE INDEX "TestScenarioSpecLink_specId_idx" ON "TestScenarioSpecLink"("specId");
+
+ALTER TABLE "TestScenarioSpecLink"
+    ADD CONSTRAINT "TestScenarioSpecLink_testScenarioId_fkey"
+    FOREIGN KEY ("testScenarioId") REFERENCES "TestScenario"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "TestScenarioSpecLink"
+    ADD CONSTRAINT "TestScenarioSpecLink_specId_fkey"
+    FOREIGN KEY ("specId") REFERENCES "Spec"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "Result_specId_startTime_idx" ON "Result"("specId", "startTime");
+CREATE INDEX "ResultError_resultId_idx" ON "ResultError"("resultId");
+CREATE INDEX "Assumption_issueId_idx" ON "Assumption"("issueId");
+CREATE INDEX "Assumption_resultErrorId_idx" ON "Assumption"("resultErrorId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,7 @@ model Spec {
   projectId String  @db.Uuid
 
   results Result[]
+  testScenarioLinks TestScenarioSpecLink[]
 
   // Unique key per project
   @@unique([projectId, key])
@@ -122,6 +123,8 @@ model Result {
   analysisFeedbackCategory        String?
   analysisFeedbackConfidence      Int?
   analysisFeedbackConclusion      String?
+
+  @@index([specId, startTime])
 }
 
 model ResultError {
@@ -139,6 +142,8 @@ model ResultError {
   result          Result?      @relation(fields: [resultId], references: [id])
   resultId        String?      @db.Uuid
   assumptions     Assumption[]
+
+  @@index([resultId])
 }
 
 model Assumption {
@@ -152,6 +157,9 @@ model Assumption {
   issueId       String       @db.Uuid
   resultError   ResultError? @relation(fields: [resultErrorId], references: [id])
   resultErrorId String?      @db.Uuid
+
+  @@index([issueId])
+  @@index([resultErrorId])
 }
 
 model User {
@@ -217,9 +225,22 @@ model TestScenario {
   projectId String  @db.Uuid
   createdBy User    @relation("TestScenarioCreatedBy", fields: [createdById], references: [id])
 
+  specLinks TestScenarioSpecLink[]
+
   @@index([projectId])
   @@index([projectId, createdAt])
   @@index([createdById])
+}
+
+model TestScenarioSpecLink {
+  testScenarioId String @db.Uuid
+  specId         String @db.Uuid
+
+  testScenario TestScenario @relation(fields: [testScenarioId], references: [id], onDelete: Cascade)
+  spec         Spec         @relation(fields: [specId], references: [id], onDelete: Cascade)
+
+  @@id([testScenarioId, specId])
+  @@index([specId])
 }
 
 model UploadApiKey {

--- a/src/controllers/testScenarioController.ts
+++ b/src/controllers/testScenarioController.ts
@@ -9,11 +9,26 @@ import {
   testScenarioListQuerySchema,
   testScenarioProjectQuerySchema,
 } from "@/schemas/testScenarioSchemas";
+import {
+  testScenarioEvidenceParamsSchema as integrationEvidenceParamsSchema,
+  testScenarioEvidenceQuerySchema as integrationEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema as integrationSpecLinkBodySchema,
+  testScenarioSpecLinkDeleteParamsSchema as integrationSpecLinkDeleteParamsSchema,
+  testScenarioSpecLinkListQuerySchema as integrationSpecLinkListQuerySchema,
+  testScenarioSpecLinkParamsSchema as integrationSpecLinkParamsSchema,
+  testScenarioSpecLinkQuerySchema as integrationSpecLinkQuerySchema,
+} from "@/schemas/testScenarioIntegrationSchemas";
 import { testScenarioService } from "@/services/testScenarioService";
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
 import {
   TestScenarioNotFoundError,
   TestScenarioValidationError,
 } from "@/types/testScenarios";
+import {
+  TestScenarioIntegrationValidationError,
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
 
 function validationMessage(error: { issues: Array<{ message: string }> }): string {
   return error.issues[0]?.message ?? "Invalid request";
@@ -24,13 +39,24 @@ function sendValidationError(res: Response, message: string): void {
 }
 
 function sendServiceError(res: Response, error: unknown, operation: string): void {
-  if (error instanceof TestScenarioValidationError) {
+  if (
+    error instanceof TestScenarioValidationError ||
+    error instanceof TestScenarioIntegrationValidationError
+  ) {
     res.status(400).json({ error: error.message });
     return;
   }
 
-  if (error instanceof TestScenarioNotFoundError) {
+  if (
+    error instanceof TestScenarioNotFoundError ||
+    error instanceof TestScenarioSpecLinkNotFoundError
+  ) {
     res.status(404).json({ error: error.message });
+    return;
+  }
+
+  if (error instanceof TestScenarioSpecLinkConflictError) {
+    res.status(409).json({ error: error.message });
     return;
   }
 
@@ -128,6 +154,134 @@ export const testScenarioController = {
       res.status(204).send();
     } catch (error) {
       sendServiceError(res, error, "delete test scenario");
+    }
+  },
+
+  async addSpecLink(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkQuerySchema.safeParse(req.query);
+    const body = integrationSpecLinkBodySchema.safeParse(req.body);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    if (!body.success) {
+      sendValidationError(res, validationMessage(body.error));
+      return;
+    }
+
+    try {
+      const link = await testScenarioIntegrationService.addSpecLink({
+        scenarioId: params.data.scenarioId,
+        projectId: query.data.projectId,
+        specId: body.data.specId,
+      });
+      res.status(201).json(link);
+    } catch (error) {
+      sendServiceError(res, error, "link Spec to test scenario");
+    }
+  },
+
+  async listSpecLinks(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkListQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const links = await testScenarioIntegrationService.listSpecLinks({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(links);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Spec links");
+    }
+  },
+
+  async removeSpecLink(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkDeleteParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      await testScenarioIntegrationService.removeSpecLink({
+        scenarioId: params.data.scenarioId,
+        specId: params.data.specId,
+        projectId: query.data.projectId,
+      });
+      res.status(204).send();
+    } catch (error) {
+      sendServiceError(res, error, "remove test scenario Spec link");
+    }
+  },
+
+  async getResults(req: Request, res: Response): Promise<void> {
+    const params = integrationEvidenceParamsSchema.safeParse(req.params);
+    const query = integrationEvidenceQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const results = await testScenarioIntegrationService.getResults({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(results);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Results");
+    }
+  },
+
+  async getIssues(req: Request, res: Response): Promise<void> {
+    const params = integrationEvidenceParamsSchema.safeParse(req.params);
+    const query = integrationEvidenceQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const issues = await testScenarioIntegrationService.getIssues({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(issues);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Issues");
     }
   },
 };

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -3,6 +3,7 @@
 
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { ErrorResponseSchema } from "./common";
+import { ResultSchema } from "./results";
 import { z } from "./zod";
 
 const TestScenarioSchema = z
@@ -55,6 +56,124 @@ const TestScenarioListResponseSchema = z
   })
   .openapi("TestScenarioListResponse");
 
+const TestScenarioSpecLinkBodySchema = z
+  .object({
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkBody");
+
+const TestScenarioSpecLinkResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkResponse");
+
+const TestScenarioLinkedSpecSchema = z
+  .object({
+    id: z.string().uuid(),
+    projectId: z.string().uuid(),
+    key: z.string(),
+    file: z.string(),
+    title: z.string(),
+    tags: z.array(z.string()),
+    annotations: z.array(z.unknown()),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("TestScenarioLinkedSpec");
+
+const TestScenarioSpecLinkListQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioSpecLinkListQuery");
+
+const TestScenarioSpecLinkDeleteParamsSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkDeleteParams");
+
+const TestScenarioEvidenceQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioEvidenceQuery");
+
+const TestScenarioSpecLinkListResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    specs: z.array(TestScenarioLinkedSpecSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioSpecLinkListResponse");
+
+const TestScenarioObservedIssueSchema = z
+  .object({
+    id: z.string().uuid(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    name: z.string(),
+    category: z.string(),
+    description: z.string().nullable(),
+    portal: z.string().nullable(),
+    service: z.string().nullable(),
+    ticket: z.string().nullable(),
+    createdBy: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        email: z.string(),
+        createdAt: z.string(),
+      })
+      .nullable(),
+    updatedBy: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        email: z.string(),
+        createdAt: z.string(),
+      })
+      .nullable(),
+  })
+  .openapi("TestScenarioObservedIssue");
+
+const TestScenarioResultsResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    linkedSpecCount: z.number().int().nonnegative(),
+    results: z.array(ResultSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioResultsResponse");
+
+const TestScenarioIssuesResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    linkedSpecCount: z.number().int().nonnegative(),
+    issues: z.array(TestScenarioObservedIssueSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioIssuesResponse");
+
 export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
   registry.register("TestScenario", TestScenarioSchema);
   registry.register(
@@ -71,6 +190,174 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
     "TestScenarioListResponse",
     TestScenarioListResponseSchema,
   );
+  registry.register(
+    "TestScenarioSpecLinkBody",
+    TestScenarioSpecLinkBodySchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkResponse",
+    TestScenarioSpecLinkResponseSchema,
+  );
+  registry.register(
+    "TestScenarioLinkedSpec",
+    TestScenarioLinkedSpecSchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkListQuery",
+    TestScenarioSpecLinkListQuerySchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkDeleteParams",
+    TestScenarioSpecLinkDeleteParamsSchema,
+  );
+  registry.register("TestScenarioEvidenceQuery", TestScenarioEvidenceQuerySchema);
+  registry.register(
+    "TestScenarioSpecLinkListResponse",
+    TestScenarioSpecLinkListResponseSchema,
+  );
+  registry.register(
+    "TestScenarioObservedIssue",
+    TestScenarioObservedIssueSchema,
+  );
+  registry.register(
+    "TestScenarioResultsResponse",
+    TestScenarioResultsResponseSchema,
+  );
+  registry.register(
+    "TestScenarioIssuesResponse",
+    TestScenarioIssuesResponseSchema,
+  );
+
+  const errorResponse = (description: string) => ({
+    description,
+    content: {
+      "application/json": { schema: ErrorResponseSchema },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links",
+    description: "Links a project-local Spec to a test scenario.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+      body: {
+        required: true,
+        content: {
+          "application/json": { schema: TestScenarioSpecLinkBodySchema },
+        },
+      },
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      201: {
+        description: "Test scenario Spec link created",
+        content: {
+          "application/json": { schema: TestScenarioSpecLinkResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or Spec link input"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario or Spec not found in the project"),
+      409: errorResponse("The scenario/Spec link already exists"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links",
+    description: "Lists Specs linked to a test scenario.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioSpecLinkListQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated linked Specs",
+        content: {
+          "application/json": {
+            schema: TestScenarioSpecLinkListResponseSchema,
+          },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links/{specId}",
+    description: "Removes a Spec link without deleting either endpoint.",
+    request: {
+      params: TestScenarioSpecLinkDeleteParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      204: { description: "Test scenario Spec link removed" },
+      400: errorResponse("Invalid scenario, project, or Spec identifier"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario Spec link not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/results",
+    description: "Lists paginated execution Results across linked Specs.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioEvidenceQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated scenario Result evidence",
+        content: {
+          "application/json": { schema: TestScenarioResultsResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/issues",
+    description: "Lists paginated observed Issues across linked Specs.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioEvidenceQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated scenario Issue evidence",
+        content: {
+          "application/json": { schema: TestScenarioIssuesResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
 
   registry.registerPath({
     method: "post",
@@ -247,9 +534,19 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
 
 export {
   CreateTestScenarioRequestSchema,
+  TestScenarioEvidenceQuerySchema,
   TestScenarioIdParamsSchema,
+  TestScenarioIssuesResponseSchema,
+  TestScenarioLinkedSpecSchema,
   TestScenarioListQuerySchema,
   TestScenarioListResponseSchema,
+  TestScenarioObservedIssueSchema,
   TestScenarioProjectQuerySchema,
+  TestScenarioResultsResponseSchema,
+  TestScenarioSpecLinkBodySchema,
+  TestScenarioSpecLinkDeleteParamsSchema,
+  TestScenarioSpecLinkListQuerySchema,
+  TestScenarioSpecLinkListResponseSchema,
+  TestScenarioSpecLinkResponseSchema,
   TestScenarioSchema,
 };

--- a/src/models/issueModel.ts
+++ b/src/models/issueModel.ts
@@ -93,6 +93,71 @@ export const issueModel = {
     });
   },
 
+  findObservedBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+    page = 1,
+    limit = 30,
+  ): Promise<PrismaIssueWithUsers[]> => {
+    if (specRecordIds.length === 0) {
+      return [];
+    }
+
+    return (await dbClient.issue.findMany({
+      where: {
+        projectId,
+        assumptions: {
+          some: {
+            resultError: {
+              result: {
+                spec: {
+                  id: { in: specRecordIds },
+                  projectId,
+                },
+                execution: { projectId },
+              },
+            },
+          },
+        },
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      include: {
+        createdBy: true,
+        updatedBy: true,
+      },
+    })) as PrismaIssueWithUsers[];
+  },
+
+  countObservedBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+  ): Promise<number> => {
+    if (specRecordIds.length === 0) {
+      return 0;
+    }
+
+    return await dbClient.issue.count({
+      where: {
+        projectId,
+        assumptions: {
+          some: {
+            resultError: {
+              result: {
+                spec: {
+                  id: { in: specRecordIds },
+                  projectId,
+                },
+                execution: { projectId },
+              },
+            },
+          },
+        },
+      },
+    });
+  },
+
   findById: async (
     id: string,
     projectId: string,

--- a/src/models/resultModel.ts
+++ b/src/models/resultModel.ts
@@ -319,6 +319,62 @@ export const resultModel = {
     });
   },
 
+  findManyBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+    page = 1,
+    limit = 30,
+  ): Promise<ResultWithRelations[]> => {
+    if (specRecordIds.length === 0) {
+      return [];
+    }
+
+    return (await dbClient.result.findMany({
+      where: {
+        spec: {
+          id: { in: specRecordIds },
+          projectId,
+        },
+        execution: { projectId },
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ startTime: "desc" }, { id: "desc" }],
+      include: {
+        spec: true,
+        execution: true,
+        errors: {
+          include: {
+            assumptions: {
+              include: {
+                issue: true,
+              },
+            },
+          },
+        },
+      },
+    })) as unknown as ResultWithRelations[];
+  },
+
+  countBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+  ): Promise<number> => {
+    if (specRecordIds.length === 0) {
+      return 0;
+    }
+
+    return await dbClient.result.count({
+      where: {
+        spec: {
+          id: { in: specRecordIds },
+          projectId,
+        },
+        execution: { projectId },
+      },
+    });
+  },
+
   findSpecTags: async (filters: ResultFilters): Promise<Prisma.JsonValue[]> => {
     const resultWhere = buildResultWhereClause(filters);
     const { spec, ...matchingResultWhere } = resultWhere;

--- a/src/models/testScenarioSpecLinkModel.ts
+++ b/src/models/testScenarioSpecLinkModel.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  Prisma,
+  Spec,
+  TestScenarioSpecLink,
+} from "@prisma/client";
+import { dbClient } from "@/prisma/client";
+
+export type TestScenarioSpecLinkWithSpec = TestScenarioSpecLink & {
+  spec: Spec;
+};
+
+const linkedSpecWhere = (
+  scenarioId: string,
+  projectId: string,
+): Prisma.TestScenarioSpecLinkWhereInput => ({
+  testScenarioId: scenarioId,
+  spec: { projectId },
+});
+
+export const testScenarioSpecLinkModel = {
+  async create(
+    data: { testScenarioId: string; specId: string },
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenarioSpecLink> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.create({ data });
+  },
+
+  async findLinkedSpecs(
+    scenarioId: string,
+    projectId: string,
+    page = 1,
+    limit = 30,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenarioSpecLinkWithSpec[]> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.findMany({
+      where: linkedSpecWhere(scenarioId, projectId),
+      include: { spec: true },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ spec: { createdAt: "desc" } }, { spec: { id: "desc" } }],
+    });
+  },
+
+  async countLinkedSpecs(
+    scenarioId: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.count({
+      where: linkedSpecWhere(scenarioId, projectId),
+    });
+  },
+
+  async findLinkedSpecIds(
+    scenarioId: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<string[]> {
+    const client = tx ?? dbClient;
+    const links = await client.testScenarioSpecLink.findMany({
+      where: linkedSpecWhere(scenarioId, projectId),
+      select: { specId: true },
+    });
+
+    return links.map(({ specId }) => specId);
+  },
+
+  async delete(
+    testScenarioId: string,
+    specId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    const result = await client.testScenarioSpecLink.deleteMany({
+      where: { testScenarioId, specId },
+    });
+
+    return result.count;
+  },
+};

--- a/src/routes/test-scenarios.ts
+++ b/src/routes/test-scenarios.ts
@@ -17,6 +17,31 @@ router.get(
   authMiddleware,
   testScenarioController.list,
 );
+router.post(
+  "/v2/test-scenarios/:scenarioId/spec-links",
+  authMiddleware,
+  testScenarioController.addSpecLink,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/spec-links",
+  authMiddleware,
+  testScenarioController.listSpecLinks,
+);
+router.delete(
+  "/v2/test-scenarios/:scenarioId/spec-links/:specId",
+  authMiddleware,
+  testScenarioController.removeSpecLink,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/results",
+  authMiddleware,
+  testScenarioController.getResults,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/issues",
+  authMiddleware,
+  testScenarioController.getIssues,
+);
 router.get(
   "/v2/test-scenarios/:scenarioId",
   authMiddleware,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -28,3 +28,20 @@ export {
 } from "./testAnalysisSchemas";
 
 export { pdfExportSchema, type PdfExportInput } from "./reportExportSchemas";
+
+export {
+  testScenarioEvidenceParamsSchema,
+  testScenarioEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema,
+  testScenarioSpecLinkDeleteParamsSchema,
+  testScenarioSpecLinkListQuerySchema,
+  testScenarioSpecLinkParamsSchema,
+  testScenarioSpecLinkQuerySchema,
+  type TestScenarioEvidenceParams,
+  type TestScenarioEvidenceQuery,
+  type TestScenarioSpecLinkBody,
+  type TestScenarioSpecLinkDeleteParams,
+  type TestScenarioSpecLinkListQuery,
+  type TestScenarioSpecLinkParams,
+  type TestScenarioSpecLinkQuery,
+} from "./testScenarioIntegrationSchemas";

--- a/src/schemas/testScenarioIntegrationSchemas.ts
+++ b/src/schemas/testScenarioIntegrationSchemas.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from "zod";
+
+const uuidSchema = z.string().uuid("Must be a valid UUID");
+
+const positiveIntegerQuerySchema = (defaultValue: number, maximum?: number) => {
+  const schema = z.coerce
+    .number()
+    .int("Must be an integer")
+    .positive("Must be greater than zero");
+
+  return (maximum === undefined ? schema : schema.max(maximum)).default(
+    defaultValue,
+  );
+};
+
+export const testScenarioSpecLinkParamsSchema = z.object({
+  scenarioId: uuidSchema,
+});
+
+export const testScenarioSpecLinkDeleteParamsSchema = z.object({
+  scenarioId: uuidSchema,
+  specId: uuidSchema,
+});
+
+export const testScenarioSpecLinkQuerySchema = z.object({
+  projectId: uuidSchema,
+});
+
+export const testScenarioSpecLinkListQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export const testScenarioSpecLinkBodySchema = z.object({
+  specId: uuidSchema,
+});
+
+export const testScenarioEvidenceParamsSchema = testScenarioSpecLinkParamsSchema;
+
+export const testScenarioEvidenceQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export type TestScenarioSpecLinkParams = z.infer<
+  typeof testScenarioSpecLinkParamsSchema
+>;
+export type TestScenarioSpecLinkDeleteParams = z.infer<
+  typeof testScenarioSpecLinkDeleteParamsSchema
+>;
+export type TestScenarioSpecLinkQuery = z.infer<
+  typeof testScenarioSpecLinkQuerySchema
+>;
+export type TestScenarioSpecLinkListQuery = z.infer<
+  typeof testScenarioSpecLinkListQuerySchema
+>;
+export type TestScenarioSpecLinkBody = z.infer<
+  typeof testScenarioSpecLinkBodySchema
+>;
+export type TestScenarioEvidenceParams = z.infer<
+  typeof testScenarioEvidenceParamsSchema
+>;
+export type TestScenarioEvidenceQuery = z.infer<
+  typeof testScenarioEvidenceQuerySchema
+>;

--- a/src/services/issueService.ts
+++ b/src/services/issueService.ts
@@ -170,6 +170,40 @@ export const issueService = {
     return serializeIssue(issueRecords);
   },
 
+  async getObservedIssuesBySpecRecordIds(params: {
+    projectId: string;
+    specRecordIds: string[];
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    issues: SerializedIssue[];
+    total: number;
+  }> {
+    if (!params.projectId) {
+      throw new Error("Project ID is required");
+    }
+
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 30;
+    const [issues, total] = await Promise.all([
+      issueModel.findObservedBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+        page,
+        limit,
+      ),
+      issueModel.countObservedBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+      ),
+    ]);
+
+    return {
+      issues: issues.map(serializeIssue),
+      total,
+    };
+  },
+
   async createIssue(issueParams: CreateIssueParams): Promise<PrismaIssue> {
     if (!issueParams?.name) {
       throw new Error("Unable to create issue without name");

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -140,6 +140,37 @@ export const resultService = {
     return normalizeResultPayload(resultRecord);
   },
 
+  async getResultsBySpecRecordIds(params: {
+    projectId: string;
+    specRecordIds: string[];
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    results: StructuredResultWithRelations[];
+    total: number;
+  }> {
+    if (!params.projectId) {
+      throw new Error("Project ID is required");
+    }
+
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 30;
+    const [results, total] = await Promise.all([
+      resultModel.findManyBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+        page,
+        limit,
+      ),
+      resultModel.countBySpecRecordIds(params.specRecordIds, params.projectId),
+    ]);
+
+    return {
+      results: results.map(normalizeResultPayload),
+      total,
+    };
+  },
+
   async getResultsStats(params: GetResultsStatsParams): Promise<ResultsStats> {
     const { projectId, dates } = params;
 

--- a/src/services/testScenarioIntegrationService.ts
+++ b/src/services/testScenarioIntegrationService.ts
@@ -1,0 +1,261 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { Prisma } from "@prisma/client";
+import { issueService } from "@/services/issueService";
+import { resultService } from "@/services/resultService";
+import { testScenarioSpecLinkModel } from "@/models/testScenarioSpecLinkModel";
+import { specModel } from "@/models/specModel";
+import { testScenarioModel } from "@/models/testScenarioModel";
+import { normalizeSpecPayload } from "@/lib/jsonPayloads";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+import {
+  TestScenarioIntegrationValidationError,
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+  type AddTestScenarioSpecLinkParams,
+  type ListTestScenarioSpecLinksParams,
+  type TestScenarioEvidenceParams,
+  type TestScenarioIssuesResponse,
+  type TestScenarioResultsResponse,
+  type TestScenarioSpecLinkResponse,
+  type TestScenarioSpecLinksResponse,
+} from "@/types/testScenarioIntegration";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+function validateContext(scenarioId: string, projectId: string): void {
+  if (!scenarioId) {
+    throw new TestScenarioIntegrationValidationError(
+      "Scenario ID is required",
+    );
+  }
+
+  if (!projectId) {
+    throw new TestScenarioIntegrationValidationError("Project ID is required");
+  }
+}
+
+function resolvePagination(
+  page: number | undefined,
+  limit: number | undefined,
+): { page: number; limit: number } {
+  const resolvedPage = page ?? DEFAULT_PAGE;
+  const resolvedLimit = limit ?? DEFAULT_LIMIT;
+
+  if (!Number.isInteger(resolvedPage) || resolvedPage < 1) {
+    throw new TestScenarioIntegrationValidationError(
+      "page must be a positive integer",
+    );
+  }
+
+  if (
+    !Number.isInteger(resolvedLimit) ||
+    resolvedLimit < 1 ||
+    resolvedLimit > MAX_LIMIT
+  ) {
+    throw new TestScenarioIntegrationValidationError(
+      `limit must be a positive integer no greater than ${MAX_LIMIT}`,
+    );
+  }
+
+  return { page: resolvedPage, limit: resolvedLimit };
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === "P2002";
+  }
+
+  if (typeof error === "object" && error !== null && "code" in error) {
+    return (error as { code?: unknown }).code === "P2002";
+  }
+
+  return false;
+}
+
+async function requireScenario(
+  scenarioId: string,
+  projectId: string,
+): Promise<void> {
+  validateContext(scenarioId, projectId);
+
+  const scenario = await testScenarioModel.findById(scenarioId, projectId);
+  if (!scenario) {
+    throw new TestScenarioNotFoundError(
+      `Test scenario with id '${scenarioId}' not found`,
+    );
+  }
+}
+
+async function resolveLinkedSpecIds(
+  scenarioId: string,
+  projectId: string,
+): Promise<{ specIds: string[]; count: number }> {
+  const [specIds, count] = await Promise.all([
+    testScenarioSpecLinkModel.findLinkedSpecIds(scenarioId, projectId),
+    testScenarioSpecLinkModel.countLinkedSpecs(scenarioId, projectId),
+  ]);
+
+  return {
+    specIds: [...new Set(specIds)],
+    count,
+  };
+}
+
+export const testScenarioIntegrationService = {
+  async addSpecLink(
+    params: AddTestScenarioSpecLinkParams,
+  ): Promise<TestScenarioSpecLinkResponse> {
+    validateContext(params.scenarioId, params.projectId);
+    if (!params.specId) {
+      throw new TestScenarioIntegrationValidationError("Spec ID is required");
+    }
+
+    const [scenario, spec] = await Promise.all([
+      testScenarioModel.findById(params.scenarioId, params.projectId),
+      specModel.findById(params.specId, params.projectId),
+    ]);
+    if (!scenario || !spec) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario or Spec not found in the requested project",
+      );
+    }
+
+    try {
+      await testScenarioSpecLinkModel.create({
+        testScenarioId: params.scenarioId,
+        specId: params.specId,
+      });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new TestScenarioSpecLinkConflictError(
+          "The Test Scenario is already linked to this Spec",
+        );
+      }
+      throw error;
+    }
+
+    return {
+      scenarioId: params.scenarioId,
+      specId: params.specId,
+    };
+  },
+
+  async listSpecLinks(
+    params: ListTestScenarioSpecLinksParams,
+  ): Promise<TestScenarioSpecLinksResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+
+    const [links, total] = await Promise.all([
+      testScenarioSpecLinkModel.findLinkedSpecs(
+        params.scenarioId,
+        params.projectId,
+        page,
+        limit,
+      ),
+      testScenarioSpecLinkModel.countLinkedSpecs(
+        params.scenarioId,
+        params.projectId,
+      ),
+    ]);
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      specs: links.map(({ spec }) => normalizeSpecPayload(spec)),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async removeSpecLink(params: AddTestScenarioSpecLinkParams): Promise<void> {
+    validateContext(params.scenarioId, params.projectId);
+    if (!params.specId) {
+      throw new TestScenarioIntegrationValidationError("Spec ID is required");
+    }
+
+    const [scenario, spec] = await Promise.all([
+      testScenarioModel.findById(params.scenarioId, params.projectId),
+      specModel.findById(params.specId, params.projectId),
+    ]);
+    if (!scenario || !spec) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario or Spec not found in the requested project",
+      );
+    }
+
+    const deletedCount = await testScenarioSpecLinkModel.delete(
+      params.scenarioId,
+      params.specId,
+    );
+    if (deletedCount === 0) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario and Spec link not found",
+      );
+    }
+  },
+
+  async getResults(
+    params: TestScenarioEvidenceParams,
+  ): Promise<TestScenarioResultsResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+    const { specIds, count: linkedSpecCount } = await resolveLinkedSpecIds(
+      params.scenarioId,
+      params.projectId,
+    );
+    const evidence = await resultService.getResultsBySpecRecordIds({
+      projectId: params.projectId,
+      specRecordIds: specIds,
+      page,
+      limit,
+    });
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      linkedSpecCount,
+      results: evidence.results,
+      total: evidence.total,
+      page,
+      limit,
+      totalPages: Math.ceil(evidence.total / limit),
+    };
+  },
+
+  async getIssues(
+    params: TestScenarioEvidenceParams,
+  ): Promise<TestScenarioIssuesResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+    const { specIds, count: linkedSpecCount } = await resolveLinkedSpecIds(
+      params.scenarioId,
+      params.projectId,
+    );
+    const evidence = await issueService.getObservedIssuesBySpecRecordIds({
+      projectId: params.projectId,
+      specRecordIds: specIds,
+      page,
+      limit,
+    });
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      linkedSpecCount,
+      issues: evidence.issues,
+      total: evidence.total,
+      page,
+      limit,
+      totalPages: Math.ceil(evidence.total / limit),
+    };
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "@/types/tests";
 export * from "@/types/ctrf";
 export * from "@/types/skills";
 export * from "@/types/testScenarios";
+export * from "@/types/testScenarioIntegration";
 
 // Express types extensions
 import type { Request } from "express";

--- a/src/types/testScenarioIntegration.ts
+++ b/src/types/testScenarioIntegration.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  SerializedIssue,
+  StructuredResultWithRelations,
+  StructuredSpec,
+} from "@/types/database";
+
+export interface AddTestScenarioSpecLinkParams {
+  scenarioId: string;
+  specId: string;
+  projectId: string;
+}
+
+export interface ListTestScenarioSpecLinksParams {
+  scenarioId: string;
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioEvidenceParams {
+  scenarioId: string;
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioSpecLinkResponse {
+  scenarioId: string;
+  specId: string;
+}
+
+export interface TestScenarioSpecLinksResponse {
+  scenarioId: string;
+  projectId: string;
+  specs: StructuredSpec[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface TestScenarioResultsResponse {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  results: StructuredResultWithRelations[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface TestScenarioIssuesResponse {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  issues: SerializedIssue[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class TestScenarioIntegrationValidationError extends Error {
+  readonly code = "TEST_SCENARIO_INTEGRATION_VALIDATION_ERROR" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioIntegrationValidationError";
+  }
+}
+
+export class TestScenarioSpecLinkNotFoundError extends Error {
+  readonly code = "TEST_SCENARIO_SPEC_LINK_NOT_FOUND" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioSpecLinkNotFoundError";
+  }
+}
+
+export class TestScenarioSpecLinkConflictError extends Error {
+  readonly code = "TEST_SCENARIO_SPEC_LINK_CONFLICT" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioSpecLinkConflictError";
+  }
+}


### PR DESCRIPTION
## Summary

- Add project-local many-to-many links between Markdown test scenarios and Specs.
- Add authenticated REST endpoints for managing Spec links and retrieving paginated Result and observed-Issue evidence.
- Add Prisma indexes, OpenAPI documentation, validation, migration coverage, and end-to-end workflow tests.

## Verification

- npm run type-check
- npm run lint
- npm run build
- npm test -- --runInBand (402 tests passed)

## Dependency

- Stacked on #77.