### PR TITLE
Edit Markdown test scenarios

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,7 @@
 url = "https://api.githubcopilot.com/mcp/"
 bearer_token_env_var = "GITHUB_PAT_TOKEN"
 enabled = true
-required = true
+required = false
 default_tools_approval_mode = "auto"
 http_headers = { "X-MCP-Tools" = "get_me,get_file_contents,list_pull_requests,pull_request_read,search_pull_requests,issue_write,create_pull_request,update_pull_request,add_issue_comment,add_reply_to_pull_request_comment,pull_request_review_write", "X-MCP-Lockdown" = "true" }
 enabled_tools = [

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,20 @@
-[features]
-multi_agent = true
-
-[agents]
-max_threads = 6
-max_depth = 1
+[mcp_servers.github_tp]
+url = "https://api.githubcopilot.com/mcp/"
+bearer_token_env_var = "GITHUB_PAT_TOKEN"
+enabled = true
+required = true
+default_tools_approval_mode = "auto"
+http_headers = { "X-MCP-Tools" = "get_me,get_file_contents,list_pull_requests,pull_request_read,search_pull_requests,issue_write,create_pull_request,update_pull_request,add_issue_comment,add_reply_to_pull_request_comment,pull_request_review_write", "X-MCP-Lockdown" = "true" }
+enabled_tools = [
+  "get_me",
+  "get_file_contents",
+  "list_pull_requests",
+  "pull_request_read",
+  "search_pull_requests",
+  "issue_write",
+  "create_pull_request",
+  "update_pull_request",
+  "add_issue_comment",
+  "add_reply_to_pull_request_comment",
+  "pull_request_review_write",
+]

--- a/__tests__/controllers/testScenarioController.test.ts
+++ b/__tests__/controllers/testScenarioController.test.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+import {
+  executeController,
+} from "@/test-utils/httpMocks";
+
+const createScenarioMock = jest.fn<() => Promise<TestScenario>>();
+const listScenariosMock = jest.fn<
+  () => Promise<{
+    scenarios: TestScenario[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  }>
+>();
+const getScenarioByIdMock = jest.fn<() => Promise<TestScenario>>();
+const deleteScenarioMock = jest.fn<() => Promise<void>>();
+
+jest.mock("@/services/testScenarioService", () => ({
+  testScenarioService: {
+    createScenario: createScenarioMock,
+    listScenarios: listScenariosMock,
+    getScenarioById: getScenarioByIdMock,
+    deleteScenario: deleteScenarioMock,
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const scenario: TestScenario = {
+  id: scenarioId,
+  projectId,
+  createdById: "33333333-3333-3333-3333-333333333333",
+  title: "Scenario",
+  contentMd: "# Exact\n\n  Markdown ✓\n",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+const authenticatedUser = {
+  id: scenario.createdById,
+  name: "Scenario Creator",
+  email: "creator@example.com",
+  status: "active",
+  role: "member",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+} as const;
+
+describe("testScenarioController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createScenarioMock.mockResolvedValue(scenario);
+    listScenariosMock.mockResolvedValue({
+      scenarios: [scenario],
+      total: 1,
+      page: 1,
+      limit: 30,
+      totalPages: 1,
+    });
+    getScenarioByIdMock.mockResolvedValue(scenario);
+    deleteScenarioMock.mockResolvedValue(undefined);
+  });
+
+  it("creates a scenario with a 201 response and preserves the response body", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: {
+        projectId,
+        title: "  Scenario  ",
+        contentMd: scenario.contentMd,
+        createdById: "99999999-9999-9999-9999-999999999999",
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toBe(scenario);
+    expect(createScenarioMock).toHaveBeenCalledWith({
+      projectId,
+      title: "Scenario",
+      contentMd: scenario.contentMd,
+      createdById: authenticatedUser.id,
+    });
+  });
+
+  it("requires an authenticated user before creating a scenario", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(createScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed input with 400 without calling the service", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: "not-a-uuid", title: " ", contentMd: "" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual(expect.objectContaining({ error: expect.any(String) }));
+    expect(createScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("maps project not-found and unexpected create errors", async () => {
+    createScenarioMock.mockRejectedValueOnce(
+      new TestScenarioNotFoundError("Project not found"),
+    );
+    const notFound = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+    expect(notFound.statusCode).toBe(404);
+
+    createScenarioMock.mockRejectedValueOnce(new Error("database unavailable"));
+    const failed = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId, title: "Scenario", contentMd: "content" },
+    });
+    expect(failed.statusCode).toBe(500);
+  });
+
+  it("returns the stable default list envelope", async () => {
+    const response = await executeController(testScenarioController.list, {
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      scenarios: [scenario],
+      page: 1,
+      limit: 30,
+    }));
+    expect(listScenariosMock).toHaveBeenCalledWith({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("rejects invalid pagination with 400", async () => {
+    const response = await executeController(testScenarioController.list, {
+      query: { projectId, page: "0", limit: "101" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(listScenariosMock).not.toHaveBeenCalled();
+  });
+
+  it("returns exact Markdown detail data and maps missing records to 404", async () => {
+    const response = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(response.statusCode).toBe(200);
+    expect((response.body as TestScenario).contentMd).toBe(scenario.contentMd);
+
+    getScenarioByIdMock.mockRejectedValueOnce(
+      new TestScenarioNotFoundError("Scenario not found"),
+    );
+    const missing = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("returns an empty 204 deletion response", async () => {
+    const response = await executeController(testScenarioController.delete, {
+      method: "DELETE",
+      params: { scenarioId },
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBeUndefined();
+    expect(deleteScenarioMock).toHaveBeenCalledWith(scenarioId, projectId);
+  });
+});

--- a/__tests__/controllers/testScenarioController.test.ts
+++ b/__tests__/controllers/testScenarioController.test.ts
@@ -19,6 +19,7 @@ const listScenariosMock = jest.fn<
   }>
 >();
 const getScenarioByIdMock = jest.fn<() => Promise<TestScenario>>();
+const updateScenarioMock = jest.fn<() => Promise<TestScenario>>();
 const deleteScenarioMock = jest.fn<() => Promise<void>>();
 
 jest.mock("@/services/testScenarioService", () => ({
@@ -26,6 +27,7 @@ jest.mock("@/services/testScenarioService", () => ({
     createScenario: createScenarioMock,
     listScenarios: listScenariosMock,
     getScenarioById: getScenarioByIdMock,
+    updateScenario: updateScenarioMock,
     deleteScenario: deleteScenarioMock,
   },
 }));
@@ -68,6 +70,7 @@ describe("testScenarioController", () => {
       totalPages: 1,
     });
     getScenarioByIdMock.mockResolvedValue(scenario);
+    updateScenarioMock.mockResolvedValue(scenario);
     deleteScenarioMock.mockResolvedValue(undefined);
   });
 
@@ -190,5 +193,66 @@ describe("testScenarioController", () => {
     expect(response.statusCode).toBe(204);
     expect(response.body).toBeUndefined();
     expect(deleteScenarioMock).toHaveBeenCalledWith(scenarioId, projectId);
+  });
+
+  it("updates a scenario with a complete persisted detail response", async () => {
+    const updatedScenario = {
+      ...scenario,
+      title: "Updated title",
+      contentMd: "# Updated",
+      updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    };
+    updateScenarioMock.mockResolvedValue(updatedScenario);
+
+    const response = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId },
+      query: { projectId },
+      body: { title: " Updated title ", contentMd: "# Updated" },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(updatedScenario);
+    expect(updateScenarioMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      title: "Updated title",
+      contentMd: "# Updated",
+    });
+  });
+
+  it("rejects invalid update bodies without changing state", async () => {
+    const response = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId },
+      query: { projectId },
+      body: { title: "Updated", projectId },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.body).toEqual(expect.objectContaining({ error: expect.any(String) }));
+    expect(updateScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("maps update not-found and unexpected errors", async () => {
+    updateScenarioMock.mockRejectedValueOnce(
+      new TestScenarioNotFoundError("Scenario not found"),
+    );
+    const notFound = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId },
+      query: { projectId },
+      body: { contentMd: "# Missing" },
+    });
+    expect(notFound.statusCode).toBe(404);
+
+    updateScenarioMock.mockRejectedValueOnce(new Error("database unavailable"));
+    const failed = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId },
+      query: { projectId },
+      body: { title: "Updated" },
+    });
+    expect(failed.statusCode).toBe(500);
   });
 });

--- a/__tests__/controllers/testScenarioIntegrationController.test.ts
+++ b/__tests__/controllers/testScenarioIntegrationController.test.ts
@@ -1,0 +1,191 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import { executeController } from "@/test-utils/httpMocks";
+import {
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
+
+const addSpecLinkMock = jest.fn<() => Promise<unknown>>();
+const listSpecLinksMock = jest.fn<() => Promise<unknown>>();
+const removeSpecLinkMock = jest.fn<() => Promise<unknown>>();
+const getResultsMock = jest.fn<() => Promise<unknown>>();
+const getIssuesMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/services/testScenarioService", () => ({
+  testScenarioService: {},
+}));
+jest.mock("@/services/testScenarioIntegrationService", () => ({
+  testScenarioIntegrationService: {
+    addSpecLink: addSpecLinkMock,
+    listSpecLinks: listSpecLinksMock,
+    removeSpecLink: removeSpecLinkMock,
+    getResults: getResultsMock,
+    getIssues: getIssuesMock,
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const specId = "33333333-3333-3333-3333-333333333333";
+
+describe("testScenarioController integration operations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    addSpecLinkMock.mockResolvedValue({ scenarioId, specId });
+    listSpecLinksMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      specs: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    removeSpecLinkMock.mockResolvedValue(undefined);
+    getResultsMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      results: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    getIssuesMock.mockResolvedValue({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      issues: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+  });
+
+  it("validates and creates a Spec link with 201", async () => {
+    const response = await executeController(testScenarioController.addSpecLink, {
+      method: "POST",
+      params: { scenarioId },
+      query: { projectId },
+      body: { specId },
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.body).toEqual({ scenarioId, specId });
+    expect(addSpecLinkMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      specId,
+    });
+  });
+
+  it("rejects malformed link input with 400 before calling the service", async () => {
+    const response = await executeController(testScenarioController.addSpecLink, {
+      params: { scenarioId: "bad" },
+      query: { projectId },
+      body: { specId },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(addSpecLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the default linked-Spec page", async () => {
+    const response = await executeController(testScenarioController.listSpecLinks, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(listSpecLinksMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("maps removal success to an empty 204 and typed misses to 404", async () => {
+    const response = await executeController(testScenarioController.removeSpecLink, {
+      method: "DELETE",
+      params: { scenarioId, specId },
+      query: { projectId },
+    });
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBeUndefined();
+
+    removeSpecLinkMock.mockRejectedValueOnce(
+      new TestScenarioSpecLinkNotFoundError("Link not found"),
+    );
+    const missing = await executeController(testScenarioController.removeSpecLink, {
+      method: "DELETE",
+      params: { scenarioId, specId },
+      query: { projectId },
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("returns independently paginated Result and Issue envelopes", async () => {
+    const resultResponse = await executeController(testScenarioController.getResults, {
+      params: { scenarioId },
+      query: { projectId, page: "2", limit: "5" },
+    });
+    const issueResponse = await executeController(testScenarioController.getIssues, {
+      params: { scenarioId },
+      query: { projectId, page: "2", limit: "5" },
+    });
+
+    expect(resultResponse.statusCode).toBe(200);
+    expect(issueResponse.statusCode).toBe(200);
+    expect(getResultsMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 5,
+    });
+    expect(getIssuesMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 5,
+    });
+  });
+
+  it("maps duplicate and unexpected service errors without message inspection", async () => {
+    addSpecLinkMock.mockRejectedValueOnce(
+      new TestScenarioSpecLinkConflictError("already linked"),
+    );
+    const conflict = await executeController(testScenarioController.addSpecLink, {
+      method: "POST",
+      params: { scenarioId },
+      query: { projectId },
+      body: { specId },
+    });
+    expect(conflict.statusCode).toBe(409);
+
+    getIssuesMock.mockRejectedValueOnce(new Error("database unavailable"));
+    const failed = await executeController(testScenarioController.getIssues, {
+      params: { scenarioId },
+      query: { projectId },
+    });
+    expect(failed.statusCode).toBe(500);
+  });
+
+  it("rejects evidence pagination above the contract limit", async () => {
+    const response = await executeController(testScenarioController.getResults, {
+      params: { scenarioId },
+      query: { projectId, page: "1", limit: "101" },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(getResultsMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateOpenAPISpec } from "@/lib/openapi";
+
+describe("test-scenario OpenAPI contract", () => {
+  it("registers all four authenticated operations under the Test Scenarios tag", () => {
+    const spec = generateOpenAPISpec();
+    const paths = spec.paths ?? {};
+    const list = paths["/api/v2/test-scenarios"]?.get;
+    const create = paths["/api/v2/test-scenarios"]?.post;
+    const detail = paths["/api/v2/test-scenarios/{scenarioId}"]?.get;
+    const remove = paths["/api/v2/test-scenarios/{scenarioId}"]?.delete;
+
+    expect(list).toBeDefined();
+    expect(create).toBeDefined();
+    expect(detail).toBeDefined();
+    expect(remove).toBeDefined();
+    expect(spec.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Test Scenarios" }),
+      ]),
+    );
+
+    for (const operation of [list, create, detail, remove]) {
+      expect(operation?.tags).toContain("Test Scenarios");
+      expect(operation?.security).toEqual([{ BearerAuth: [] }]);
+      expect(operation?.responses?.["400"]).toBeDefined();
+      expect(operation?.responses?.["401"]).toBeDefined();
+    }
+    expect(detail?.responses?.["404"]).toBeDefined();
+    expect(remove?.responses?.["404"]).toBeDefined();
+    expect(create?.responses?.["404"]).toBeDefined();
+    expect(list?.responses?.["500"]).toBeDefined();
+  });
+
+  it("documents the exact resource and pagination envelope", () => {
+    const spec = generateOpenAPISpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    expect(schemas.TestScenario).toBeDefined();
+    expect(schemas.CreateTestScenarioRequest).toBeDefined();
+    expect(schemas.TestScenarioListResponse).toBeDefined();
+    expect(schemas.TestScenarioListQuery).toBeDefined();
+
+    const scenarioSchema = schemas.TestScenario as {
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+    const createSchema = schemas.CreateTestScenarioRequest as {
+      properties?: Record<string, unknown>;
+    };
+    expect(scenarioSchema.required).toContain("createdById");
+    expect(scenarioSchema.properties?.createdById).toBeDefined();
+    expect(createSchema.properties?.createdById).toBeUndefined();
+
+    const listResponse = schemas.TestScenarioListResponse as {
+      properties?: Record<string, unknown>;
+    };
+    expect(Object.keys(listResponse.properties ?? {})).toEqual([
+      "scenarios",
+      "total",
+      "page",
+      "limit",
+      "totalPages",
+    ]);
+
+    const listQuery = schemas.TestScenarioListQuery as {
+      properties?: Record<string, { maximum?: number; minimum?: number }>;
+    };
+    expect(listQuery.properties?.limit?.minimum).toBe(1);
+    expect(listQuery.properties?.limit?.maximum).toBe(100);
+  });
+
+  it("documents 201 creation and empty 204 deletion", () => {
+    const spec = generateOpenAPISpec();
+
+    expect(
+      spec.paths?.["/api/v2/test-scenarios"]?.post?.responses?.["201"],
+    ).toBeDefined();
+    expect(
+      spec.paths?.["/api/v2/test-scenarios/{scenarioId}"]?.delete?.responses?.[
+        "204"
+      ],
+    ).toEqual(expect.objectContaining({ description: "Test scenario deleted" }));
+  });
+});

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -4,17 +4,19 @@
 import { generateOpenAPISpec } from "@/lib/openapi";
 
 describe("test-scenario OpenAPI contract", () => {
-  it("registers all four authenticated operations under the Test Scenarios tag", () => {
+  it("registers authenticated scenario operations under the Test Scenarios tag", () => {
     const spec = generateOpenAPISpec();
     const paths = spec.paths ?? {};
     const list = paths["/api/v2/test-scenarios"]?.get;
     const create = paths["/api/v2/test-scenarios"]?.post;
     const detail = paths["/api/v2/test-scenarios/{scenarioId}"]?.get;
+    const update = paths["/api/v2/test-scenarios/{scenarioId}"]?.patch;
     const remove = paths["/api/v2/test-scenarios/{scenarioId}"]?.delete;
 
     expect(list).toBeDefined();
     expect(create).toBeDefined();
     expect(detail).toBeDefined();
+    expect(update).toBeDefined();
     expect(remove).toBeDefined();
     expect(spec.tags).toEqual(
       expect.arrayContaining([
@@ -22,12 +24,15 @@ describe("test-scenario OpenAPI contract", () => {
       ]),
     );
 
-    for (const operation of [list, create, detail, remove]) {
+    for (const operation of [list, create, detail, update, remove]) {
       expect(operation?.tags).toContain("Test Scenarios");
       expect(operation?.security).toEqual([{ BearerAuth: [] }]);
       expect(operation?.responses?.["400"]).toBeDefined();
       expect(operation?.responses?.["401"]).toBeDefined();
     }
+    expect(update?.responses?.["200"]).toBeDefined();
+    expect(update?.responses?.["404"]).toBeDefined();
+    expect(update?.responses?.["500"]).toBeDefined();
     expect(detail?.responses?.["404"]).toBeDefined();
     expect(remove?.responses?.["404"]).toBeDefined();
     expect(create?.responses?.["404"]).toBeDefined();
@@ -40,6 +45,7 @@ describe("test-scenario OpenAPI contract", () => {
 
     expect(schemas.TestScenario).toBeDefined();
     expect(schemas.CreateTestScenarioRequest).toBeDefined();
+    expect(schemas.UpdateTestScenarioRequest).toBeDefined();
     expect(schemas.TestScenarioListResponse).toBeDefined();
     expect(schemas.TestScenarioListQuery).toBeDefined();
 
@@ -70,6 +76,53 @@ describe("test-scenario OpenAPI contract", () => {
     };
     expect(listQuery.properties?.limit?.minimum).toBe(1);
     expect(listQuery.properties?.limit?.maximum).toBe(100);
+  });
+
+  it("documents strict partial alternatives and reuses the detail response", () => {
+    const spec = generateOpenAPISpec();
+    const schemas = spec.components?.schemas ?? {};
+    const updateSchema = schemas.UpdateTestScenarioRequest as {
+      anyOf?: Array<{
+        additionalProperties?: boolean;
+        required?: string[];
+        properties?: Record<string, { pattern?: string } | unknown>;
+      }>;
+      oneOf?: Array<{
+        additionalProperties?: boolean;
+        required?: string[];
+        properties?: Record<string, { pattern?: string } | unknown>;
+      }>;
+    };
+    const alternatives = updateSchema.oneOf ?? updateSchema.anyOf;
+
+    expect(alternatives).toHaveLength(2);
+    expect(alternatives?.[0]?.additionalProperties).toBe(false);
+    expect(alternatives?.[1]?.additionalProperties).toBe(false);
+    expect(alternatives?.map((alternative) => alternative.required)).toEqual([
+      ["title"],
+      ["contentMd"],
+    ]);
+    for (const alternative of alternatives ?? []) {
+      expect(Object.keys(alternative.properties ?? {}).sort()).toEqual([
+        "contentMd",
+        "title",
+      ]);
+      expect(alternative.properties?.projectId).toBeUndefined();
+      expect(alternative.properties?.createdById).toBeUndefined();
+      expect(alternative.properties?.createdAt).toBeUndefined();
+      expect(alternative.properties?.updatedAt).toBeUndefined();
+      expect(
+        (alternative.properties?.title as { pattern?: string } | undefined)
+          ?.pattern,
+      ).toBe("\\S");
+    }
+
+    const update = spec.paths?.["/api/v2/test-scenarios/{scenarioId}"]?.patch;
+    const responseSchema = update?.responses?.["200"]?.content?.[
+      "application/json"
+    ]?.schema;
+    expect(responseSchema).toEqual({ $ref: "#/components/schemas/TestScenario" });
+    expect(spec.paths?.["/api/v2/test-scenarios/{scenarioId}"]?.put).toBeUndefined();
   });
 
   it("documents 201 creation and empty 204 deletion", () => {

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -84,4 +84,74 @@ describe("test-scenario OpenAPI contract", () => {
       ],
     ).toEqual(expect.objectContaining({ description: "Test scenario deleted" }));
   });
+
+  it("registers all five integration operations with bearer security", () => {
+    const spec = generateOpenAPISpec();
+    const paths = spec.paths ?? {};
+    const operations = [
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.post,
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.get,
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links/{specId}"]?.delete,
+      paths["/api/v2/test-scenarios/{scenarioId}/results"]?.get,
+      paths["/api/v2/test-scenarios/{scenarioId}/issues"]?.get,
+    ];
+
+    for (const operation of operations) {
+      expect(operation).toBeDefined();
+      expect(operation?.tags).toContain("Test Scenarios");
+      expect(operation?.security).toEqual([{ BearerAuth: [] }]);
+      expect(operation?.responses?.["400"]).toBeDefined();
+      expect(operation?.responses?.["401"]).toBeDefined();
+      expect(operation?.responses?.["404"]).toBeDefined();
+      expect(operation?.responses?.["500"]).toBeDefined();
+    }
+
+    expect(
+      paths["/api/v2/test-scenarios/{scenarioId}/spec-links"]?.post?.responses?.[
+        "409"
+      ],
+    ).toBeDefined();
+  });
+
+  it("documents reusable integration schemas and exact response envelopes", () => {
+    const spec = generateOpenAPISpec();
+    const schemas = spec.components?.schemas ?? {};
+
+    expect(schemas.TestScenarioSpecLinkBody).toBeDefined();
+    expect(schemas.TestScenarioSpecLinkResponse).toBeDefined();
+    expect(schemas.TestScenarioLinkedSpec).toBeDefined();
+    expect(schemas.TestScenarioSpecLinkListResponse).toBeDefined();
+    expect(schemas.TestScenarioResultsResponse).toBeDefined();
+    expect(schemas.TestScenarioIssuesResponse).toBeDefined();
+    expect(schemas.TestScenarioEvidenceQuery).toBeDefined();
+
+    for (const name of [
+      "TestScenarioSpecLinkListResponse",
+      "TestScenarioResultsResponse",
+      "TestScenarioIssuesResponse",
+    ]) {
+      const schema = schemas[name] as { properties?: Record<string, unknown> };
+      expect(Object.keys(schema.properties ?? {})).toEqual(
+        name === "TestScenarioSpecLinkListResponse"
+          ? ["scenarioId", "projectId", "specs", "total", "page", "limit", "totalPages"]
+          : [
+              "scenarioId",
+              "projectId",
+              "linkedSpecCount",
+              name === "TestScenarioResultsResponse" ? "results" : "issues",
+              "total",
+              "page",
+              "limit",
+              "totalPages",
+            ],
+      );
+    }
+
+    const query = schemas.TestScenarioEvidenceQuery as {
+      properties?: Record<string, { maximum?: number; minimum?: number }>;
+    };
+    expect(query.properties?.page?.minimum).toBe(1);
+    expect(query.properties?.limit?.minimum).toBe(1);
+    expect(query.properties?.limit?.maximum).toBe(100);
+  });
 });

--- a/__tests__/models/projectModel.test.ts
+++ b/__tests__/models/projectModel.test.ts
@@ -63,6 +63,9 @@ describe("projectModel", () => {
         dailyExecutionMetric: {
           deleteMany: mockResolved({ count: 1 }),
         },
+        testScenario: {
+          deleteMany: mockResolved({ count: 1 }),
+        },
         uploadApiKey: {
           deleteMany: mockResolved({ count: 0 }),
         },
@@ -82,22 +85,30 @@ describe("projectModel", () => {
       expect(mockTxClient.dailyExecutionMetric.deleteMany).toHaveBeenCalledWith({
         where: { projectId },
       });
+      expect(mockTxClient.testScenario.deleteMany).toHaveBeenCalledWith({
+        where: { projectId },
+      });
       const dailyMetricsDeleteOrder =
         mockTxClient.dailyExecutionMetric.deleteMany.mock
           .invocationCallOrder[0];
+      const scenarioDeleteOrder =
+        mockTxClient.testScenario.deleteMany.mock.invocationCallOrder[0];
       const projectDeleteOrder =
         mockTxClient.project.delete.mock.invocationCallOrder[0];
 
       expect(dailyMetricsDeleteOrder).toEqual(expect.any(Number));
+      expect(scenarioDeleteOrder).toEqual(expect.any(Number));
       expect(projectDeleteOrder).toEqual(expect.any(Number));
 
       if (
         dailyMetricsDeleteOrder === undefined ||
+        scenarioDeleteOrder === undefined ||
         projectDeleteOrder === undefined
       ) {
         throw new Error("Expected delete calls to be recorded");
       }
 
+      expect(scenarioDeleteOrder).toBeLessThan(projectDeleteOrder);
       expect(dailyMetricsDeleteOrder).toBeLessThan(projectDeleteOrder);
       expect(mockTxClient.project.delete).toHaveBeenCalledWith({
         where: { id: projectId },

--- a/__tests__/models/testScenarioEvidenceModel.test.ts
+++ b/__tests__/models/testScenarioEvidenceModel.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+const resultFindManyMock = jest.fn<() => Promise<unknown>>();
+const resultCountMock = jest.fn<() => Promise<unknown>>();
+const issueFindManyMock = jest.fn<() => Promise<unknown>>();
+const issueCountMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    result: {
+      findMany: resultFindManyMock,
+      count: resultCountMock,
+    },
+    issue: {
+      findMany: issueFindManyMock,
+      count: issueCountMock,
+    },
+  },
+}));
+
+import { issueModel } from "@/models/issueModel";
+import { resultModel } from "@/models/resultModel";
+
+describe("scenario evidence model predicates", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resultFindManyMock.mockResolvedValue([]);
+    resultCountMock.mockResolvedValue(0);
+    issueFindManyMock.mockResolvedValue([]);
+    issueCountMock.mockResolvedValue(0);
+  });
+
+  it("queries Results by database Spec IDs and both project relations", async () => {
+    await resultModel.findManyBySpecRecordIds(
+      ["spec-1", "spec-2"],
+      "project-1",
+      2,
+      5,
+    );
+    await resultModel.countBySpecRecordIds(
+      ["spec-1", "spec-2"],
+      "project-1",
+    );
+
+    expect(resultFindManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        spec: { id: { in: ["spec-1", "spec-2"] }, projectId: "project-1" },
+        execution: { projectId: "project-1" },
+      },
+      skip: 5,
+      take: 5,
+      orderBy: [{ startTime: "desc" }, { id: "desc" }],
+    }));
+    expect(resultCountMock).toHaveBeenCalledWith({
+      where: {
+        spec: { id: { in: ["spec-1", "spec-2"] }, projectId: "project-1" },
+        execution: { projectId: "project-1" },
+      },
+    });
+  });
+
+  it("queries unique Issues through Assumption to Result evidence without confirmation filtering", async () => {
+    await issueModel.findObservedBySpecRecordIds(
+      ["spec-1"],
+      "project-1",
+      1,
+      30,
+    );
+    await issueModel.countObservedBySpecRecordIds(["spec-1"], "project-1");
+
+    const expectedEvidence = {
+      projectId: "project-1",
+      assumptions: {
+        some: {
+          resultError: {
+            result: {
+              spec: { id: { in: ["spec-1"] }, projectId: "project-1" },
+              execution: { projectId: "project-1" },
+            },
+          },
+        },
+      },
+    };
+    expect(issueFindManyMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: expectedEvidence,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    }));
+    expect(issueCountMock).toHaveBeenCalledWith({ where: expectedEvidence });
+    const issueQuery = (issueFindManyMock.mock.calls as unknown[][])[0]?.[0];
+    expect(JSON.stringify(issueQuery)).not.toContain("isConfirmed");
+  });
+
+  it("does not query the database for empty linked Spec ID sets", async () => {
+    await expect(
+      resultModel.findManyBySpecRecordIds([], "project-1"),
+    ).resolves.toEqual([]);
+    await expect(
+      resultModel.countBySpecRecordIds([], "project-1"),
+    ).resolves.toBe(0);
+    await expect(
+      issueModel.findObservedBySpecRecordIds([], "project-1"),
+    ).resolves.toEqual([]);
+    await expect(
+      issueModel.countObservedBySpecRecordIds([], "project-1"),
+    ).resolves.toBe(0);
+
+    expect(resultFindManyMock).not.toHaveBeenCalled();
+    expect(resultCountMock).not.toHaveBeenCalled();
+    expect(issueFindManyMock).not.toHaveBeenCalled();
+    expect(issueCountMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/models/testScenarioModel.test.ts
+++ b/__tests__/models/testScenarioModel.test.ts
@@ -1,0 +1,111 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+
+const createMock = jest.fn<() => Promise<TestScenario>>();
+const findManyMock = jest.fn<() => Promise<TestScenario[]>>();
+const countMock = jest.fn<() => Promise<number>>();
+const findFirstMock = jest.fn<() => Promise<TestScenario | null>>();
+const deleteManyMock = jest.fn<() => Promise<{ count: number }>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    testScenario: {
+      create: createMock,
+      findMany: findManyMock,
+      count: countMock,
+      findFirst: findFirstMock,
+      deleteMany: deleteManyMock,
+    },
+  },
+}));
+
+import { testScenarioModel } from "@/models/testScenarioModel";
+
+const scenario: TestScenario = {
+  id: "11111111-1111-1111-1111-111111111111",
+  projectId: "22222222-2222-2222-2222-222222222222",
+  createdById: "33333333-3333-3333-3333-333333333333",
+  title: "Login",
+  contentMd: "# Login",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("testScenarioModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createMock.mockResolvedValue(scenario);
+    findManyMock.mockResolvedValue([scenario]);
+    countMock.mockResolvedValue(1);
+    findFirstMock.mockResolvedValue(scenario);
+    deleteManyMock.mockResolvedValue({ count: 1 });
+  });
+
+  it("creates only the authored scenario fields", async () => {
+    await testScenarioModel.create({
+      projectId: scenario.projectId,
+      title: scenario.title,
+      contentMd: scenario.contentMd,
+      createdById: scenario.createdById,
+    });
+
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        projectId: scenario.projectId,
+        title: scenario.title,
+        contentMd: scenario.contentMd,
+        createdById: scenario.createdById,
+      },
+    });
+  });
+
+  it("lists by project with deterministic ordering and offset pagination", async () => {
+    await testScenarioModel.findMany(scenario.projectId, 3, 10);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+      skip: 20,
+      take: 10,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+  });
+
+  it("uses the same project predicate for list and count", async () => {
+    await testScenarioModel.findMany(scenario.projectId);
+    await testScenarioModel.count(scenario.projectId);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+      skip: 0,
+      take: 30,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+    expect(countMock).toHaveBeenCalledWith({
+      where: { projectId: scenario.projectId },
+    });
+  });
+
+  it("looks up by the composite scenario and project identity", async () => {
+    await testScenarioModel.findById(scenario.id, scenario.projectId);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: scenario.id, projectId: scenario.projectId },
+    });
+  });
+
+  it("deletes only the composite identity and returns the affected count", async () => {
+    const deletedCount = await testScenarioModel.delete(
+      scenario.id,
+      scenario.projectId,
+    );
+
+    expect(deletedCount).toBe(1);
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { id: scenario.id, projectId: scenario.projectId },
+    });
+  });
+});

--- a/__tests__/models/testScenarioModel.test.ts
+++ b/__tests__/models/testScenarioModel.test.ts
@@ -3,13 +3,24 @@
 
 import "@/test-utils/testEnv";
 import { jest } from "@jest/globals";
-import type { TestScenario } from "@prisma/client";
+import type { Prisma, TestScenario } from "@prisma/client";
 
 const createMock = jest.fn<() => Promise<TestScenario>>();
 const findManyMock = jest.fn<() => Promise<TestScenario[]>>();
 const countMock = jest.fn<() => Promise<number>>();
 const findFirstMock = jest.fn<() => Promise<TestScenario | null>>();
+const updateMock = jest.fn<
+  (args: {
+    where: { id: string };
+    data: { title?: string; contentMd?: string };
+  }) => Promise<TestScenario>
+>();
 const deleteManyMock = jest.fn<() => Promise<{ count: number }>>();
+const transactionMock = jest.fn<
+  (
+    callback: (tx: Prisma.TransactionClient) => Promise<TestScenario | null>,
+  ) => Promise<TestScenario | null>
+>();
 
 jest.mock("@/prisma/client", () => ({
   dbClient: {
@@ -18,8 +29,10 @@ jest.mock("@/prisma/client", () => ({
       findMany: findManyMock,
       count: countMock,
       findFirst: findFirstMock,
+      update: updateMock,
       deleteMany: deleteManyMock,
     },
+    $transaction: transactionMock,
   },
 }));
 
@@ -42,7 +55,16 @@ describe("testScenarioModel", () => {
     findManyMock.mockResolvedValue([scenario]);
     countMock.mockResolvedValue(1);
     findFirstMock.mockResolvedValue(scenario);
+    updateMock.mockResolvedValue(scenario);
     deleteManyMock.mockResolvedValue({ count: 1 });
+    transactionMock.mockImplementation(async (callback) =>
+      callback({
+        testScenario: {
+          findFirst: findFirstMock,
+          update: updateMock,
+        },
+      } as unknown as Prisma.TransactionClient),
+    );
   });
 
   it("creates only the authored scenario fields", async () => {
@@ -106,6 +128,69 @@ describe("testScenarioModel", () => {
     expect(deletedCount).toBe(1);
     expect(deleteManyMock).toHaveBeenCalledWith({
       where: { id: scenario.id, projectId: scenario.projectId },
+    });
+  });
+
+  it("updates only a scenario found in the requested project transaction", async () => {
+    const updated = { ...scenario, title: "Updated" };
+    updateMock.mockResolvedValue(updated);
+
+    await expect(
+      testScenarioModel.update(
+        scenario.id,
+        scenario.projectId,
+        { title: "Updated" },
+      ),
+    ).resolves.toBe(updated);
+
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: scenario.id, projectId: scenario.projectId },
+    });
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: scenario.id },
+      data: { title: "Updated" },
+    });
+  });
+
+  it("returns null and does not mutate on a cross-project miss", async () => {
+    findFirstMock.mockResolvedValue(null);
+
+    await expect(
+      testScenarioModel.update(
+        scenario.id,
+        "99999999-9999-9999-9999-999999999999",
+        { contentMd: "# Unchanged" },
+      ),
+    ).resolves.toBeNull();
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("passes combined fields atomically and excludes immutable metadata", async () => {
+    await testScenarioModel.update(scenario.id, scenario.projectId, {
+      title: "Updated",
+      contentMd: "# Updated",
+    });
+
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: scenario.id },
+      data: { title: "Updated", contentMd: "# Updated" },
+    });
+    expect(Object.keys(updateMock.mock.calls[0]?.[0]?.data ?? {})).toEqual([
+      "title",
+      "contentMd",
+    ]);
+  });
+
+  it("preserves omitted fields by passing only supplied authored data", async () => {
+    await testScenarioModel.update(scenario.id, scenario.projectId, {
+      contentMd: "# Markdown only",
+    });
+
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: scenario.id },
+      data: { contentMd: "# Markdown only" },
     });
   });
 });

--- a/__tests__/models/testScenarioSpecLinkModel.test.ts
+++ b/__tests__/models/testScenarioSpecLinkModel.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+const createMock = jest.fn<() => Promise<unknown>>();
+const findManyMock = jest.fn<() => Promise<unknown>>();
+const countMock = jest.fn<() => Promise<unknown>>();
+const deleteManyMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/prisma/client", () => ({
+  dbClient: {
+    testScenarioSpecLink: {
+      create: createMock,
+      findMany: findManyMock,
+      count: countMock,
+      deleteMany: deleteManyMock,
+    },
+  },
+}));
+
+import { testScenarioSpecLinkModel } from "@/models/testScenarioSpecLinkModel";
+
+describe("testScenarioSpecLinkModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createMock.mockResolvedValue({ testScenarioId: "scenario-1", specId: "spec-1" });
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    deleteManyMock.mockResolvedValue({ count: 1 });
+  });
+
+  it("creates one composite link and leaves duplicate enforcement to Prisma", async () => {
+    await testScenarioSpecLinkModel.create({
+      testScenarioId: "scenario-1",
+      specId: "spec-1",
+    });
+
+    expect(createMock).toHaveBeenCalledWith({
+      data: { testScenarioId: "scenario-1", specId: "spec-1" },
+    });
+  });
+
+  it("lists only same-project linked Specs with deterministic ordering", async () => {
+    await testScenarioSpecLinkModel.findLinkedSpecs(
+      "scenario-1",
+      "project-1",
+      2,
+      10,
+    );
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+      include: { spec: true },
+      skip: 10,
+      take: 10,
+      orderBy: [
+        { spec: { createdAt: "desc" } },
+        { spec: { id: "desc" } },
+      ],
+    });
+  });
+
+  it("resolves linked Spec IDs and counts through the same project predicate", async () => {
+    findManyMock.mockResolvedValueOnce([{ specId: "spec-1" }, { specId: "spec-2" }]);
+    countMock.mockResolvedValue(2);
+
+    await expect(
+      testScenarioSpecLinkModel.findLinkedSpecIds("scenario-1", "project-1"),
+    ).resolves.toEqual(["spec-1", "spec-2"]);
+    await expect(
+      testScenarioSpecLinkModel.countLinkedSpecs("scenario-1", "project-1"),
+    ).resolves.toBe(2);
+
+    expect(findManyMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+      select: { specId: true },
+    });
+    expect(countMock).toHaveBeenCalledWith({
+      where: {
+        testScenarioId: "scenario-1",
+        spec: { projectId: "project-1" },
+      },
+    });
+  });
+
+  it("deletes only the association and reports whether it existed", async () => {
+    await expect(
+      testScenarioSpecLinkModel.delete("scenario-1", "spec-1"),
+    ).resolves.toBe(1);
+
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { testScenarioId: "scenario-1", specId: "spec-1" },
+    });
+  });
+});

--- a/__tests__/prisma/testScenarioMigration.test.ts
+++ b/__tests__/prisma/testScenarioMigration.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+describe("test-scenario persistence contract", () => {
+  const schema = readFileSync(
+    path.join(process.cwd(), "prisma/schema.prisma"),
+    "utf8",
+  );
+  const migration = readFileSync(
+    path.join(
+      process.cwd(),
+      "prisma/migrations/20260824120000_add_test_scenarios/migration.sql",
+    ),
+    "utf8",
+  );
+
+  it("defines a project-owned Markdown record with creator and timestamp fields", () => {
+    expect(schema).toMatch(
+      /model TestScenario \{[\s\S]*id\s+String\s+@id\s+@default\(uuid\(\)\)\s+@db\.Uuid[\s\S]*contentMd\s+String\s+@db\.Text[\s\S]*projectId\s+String\s+@db\.Uuid/,
+    );
+    expect(schema).toContain("testScenarios TestScenario[]");
+    expect(schema).toContain(
+      'testScenariosCreated TestScenario[] @relation("TestScenarioCreatedBy")',
+    );
+    expect(schema).toContain(
+      'createdBy User    @relation("TestScenarioCreatedBy"',
+    );
+  });
+
+  it("creates only the independent scenario table and project foreign key", () => {
+    expect(migration).toContain('CREATE TABLE "TestScenario"');
+    expect(migration).toContain('"contentMd" TEXT NOT NULL');
+    expect(migration).toContain('"createdById" UUID NOT NULL');
+    expect(migration).toContain('"TestScenario_projectId_idx"');
+    expect(migration).toContain('"TestScenario_projectId_createdAt_idx"');
+    expect(migration).toContain('"TestScenario_projectId_fkey"');
+    expect(migration).toContain('"TestScenario_createdById_idx"');
+    expect(migration).toContain('"TestScenario_createdById_fkey"');
+    expect(migration).not.toContain('"Spec"');
+    expect(migration).not.toContain('"Execution"');
+    expect(migration).not.toContain('"Issue"');
+  });
+});

--- a/__tests__/prisma/testScenarioMigration.test.ts
+++ b/__tests__/prisma/testScenarioMigration.test.ts
@@ -16,6 +16,13 @@ describe("test-scenario persistence contract", () => {
     ),
     "utf8",
   );
+  const linkMigration = readFileSync(
+    path.join(
+      process.cwd(),
+      "prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql",
+    ),
+    "utf8",
+  );
 
   it("defines a project-owned Markdown record with creator and timestamp fields", () => {
     expect(schema).toMatch(
@@ -42,5 +49,38 @@ describe("test-scenario persistence contract", () => {
     expect(migration).not.toContain('"Spec"');
     expect(migration).not.toContain('"Execution"');
     expect(migration).not.toContain('"Issue"');
+  });
+
+  it("defines a cascading unique scenario/Spec join without changing existing data", () => {
+    expect(schema).toMatch(
+      /model TestScenarioSpecLink \{[\s\S]*testScenarioId\s+String @db\.Uuid[\s\S]*specId\s+String @db\.Uuid[\s\S]*@@id\(\[testScenarioId, specId\]\)[\s\S]*@@index\(\[specId\]\)/,
+    );
+    expect(schema).toContain("specLinks TestScenarioSpecLink[]");
+    expect(schema).toContain("testScenarioLinks TestScenarioSpecLink[]");
+    expect(linkMigration).toContain('CREATE TABLE "TestScenarioSpecLink"');
+    expect(linkMigration).toContain(
+      'CONSTRAINT "TestScenarioSpecLink_pkey" PRIMARY KEY ("testScenarioId", "specId")',
+    );
+    expect(linkMigration).toContain(
+      'REFERENCES "TestScenario"("id") ON DELETE CASCADE',
+    );
+    expect(linkMigration).toContain(
+      'REFERENCES "Spec"("id") ON DELETE CASCADE',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "TestScenarioSpecLink_specId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Result_specId_startTime_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "ResultError_resultId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Assumption_issueId_idx"',
+    );
+    expect(linkMigration).toContain(
+      'CREATE INDEX "Assumption_resultErrorId_idx"',
+    );
   });
 });

--- a/__tests__/routes/test-scenarios.test.ts
+++ b/__tests__/routes/test-scenarios.test.ts
@@ -5,13 +5,21 @@ import "@/test-utils/testEnv";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { jest } from "@jest/globals";
+import type { NextFunction, Request, Response } from "express";
 
-const authMiddlewareMock = jest.fn();
+const authMiddlewareMock = jest.fn<
+  (req: Request, res: Response, next: NextFunction) => void
+>();
 const controllerMocks = {
-  create: jest.fn(),
-  list: jest.fn(),
-  getById: jest.fn(),
-  delete: jest.fn(),
+  create: jest.fn<(req: Request, res: Response) => void>(),
+  list: jest.fn<(req: Request, res: Response) => void>(),
+  addSpecLink: jest.fn<(req: Request, res: Response) => void>(),
+  listSpecLinks: jest.fn<(req: Request, res: Response) => void>(),
+  removeSpecLink: jest.fn<(req: Request, res: Response) => void>(),
+  getResults: jest.fn<(req: Request, res: Response) => void>(),
+  getIssues: jest.fn<(req: Request, res: Response) => void>(),
+  getById: jest.fn<(req: Request, res: Response) => void>(),
+  delete: jest.fn<(req: Request, res: Response) => void>(),
 };
 
 jest.mock("@/middleware/authMiddleware", () => ({
@@ -41,7 +49,7 @@ describe("test-scenario routes", () => {
     jest.clearAllMocks();
   });
 
-  it("registers exactly create, list, detail, and delete operations", () => {
+  it("registers the five integration operations alongside scenario CRUD", () => {
     const routes = routeLayers()
       .filter((layer) => layer.route)
       .map((layer) => {
@@ -53,6 +61,11 @@ describe("test-scenario routes", () => {
     expect(routes).toEqual([
       "post /v2/test-scenarios",
       "get /v2/test-scenarios",
+      "post /v2/test-scenarios/:scenarioId/spec-links",
+      "get /v2/test-scenarios/:scenarioId/spec-links",
+      "delete /v2/test-scenarios/:scenarioId/spec-links/:specId",
+      "get /v2/test-scenarios/:scenarioId/results",
+      "get /v2/test-scenarios/:scenarioId/issues",
       "get /v2/test-scenarios/:scenarioId",
       "delete /v2/test-scenarios/:scenarioId",
     ]);
@@ -71,6 +84,19 @@ describe("test-scenario routes", () => {
     }
   });
 
+  it("keeps nested integration routes before the scenario detail route", () => {
+    const routes = routeLayers()
+      .filter((layer) => layer.route)
+      .map((layer) => layer.route?.path);
+    const detailIndex = routes.indexOf("/v2/test-scenarios/:scenarioId");
+    const nestedIndexes = routes
+      .map((route, index) => (route?.startsWith("/v2/test-scenarios/:scenarioId/") ? index : -1))
+      .filter((index) => index >= 0);
+
+    expect(detailIndex).toBeGreaterThan(-1);
+    expect(nestedIndexes.every((index) => index < detailIndex)).toBe(true);
+  });
+
   it("mounts the router in the central API router", () => {
     const source = readFileSync(
       path.join(process.cwd(), "src/routes/index.ts"),
@@ -83,5 +109,24 @@ describe("test-scenario routes", () => {
 
   it("does not introduce MCP operations", () => {
     expect(controllerMocks).not.toHaveProperty("mcp");
+  });
+
+  it("hands each integration route to the matching controller after auth", () => {
+    const expectedHandlers = new Map([
+      ["post /v2/test-scenarios/:scenarioId/spec-links", controllerMocks.addSpecLink],
+      ["get /v2/test-scenarios/:scenarioId/spec-links", controllerMocks.listSpecLinks],
+      ["delete /v2/test-scenarios/:scenarioId/spec-links/:specId", controllerMocks.removeSpecLink],
+      ["get /v2/test-scenarios/:scenarioId/results", controllerMocks.getResults],
+      ["get /v2/test-scenarios/:scenarioId/issues", controllerMocks.getIssues],
+    ]);
+
+    for (const [routeName, controller] of expectedHandlers) {
+      const route = routeLayers().find((layer) => {
+        const metadata = layer.route;
+        return metadata && `${Object.keys(metadata.methods)[0]} ${metadata.path}` === routeName;
+      });
+
+      expect(route?.route?.stack.some((entry) => entry.handle === controller)).toBe(true);
+    }
   });
 });

--- a/__tests__/routes/test-scenarios.test.ts
+++ b/__tests__/routes/test-scenarios.test.ts
@@ -18,6 +18,7 @@ const controllerMocks = {
   removeSpecLink: jest.fn<(req: Request, res: Response) => void>(),
   getResults: jest.fn<(req: Request, res: Response) => void>(),
   getIssues: jest.fn<(req: Request, res: Response) => void>(),
+  update: jest.fn<(req: Request, res: Response) => void>(),
   getById: jest.fn<(req: Request, res: Response) => void>(),
   delete: jest.fn<(req: Request, res: Response) => void>(),
 };
@@ -66,10 +67,10 @@ describe("test-scenario routes", () => {
       "delete /v2/test-scenarios/:scenarioId/spec-links/:specId",
       "get /v2/test-scenarios/:scenarioId/results",
       "get /v2/test-scenarios/:scenarioId/issues",
+      "patch /v2/test-scenarios/:scenarioId",
       "get /v2/test-scenarios/:scenarioId",
       "delete /v2/test-scenarios/:scenarioId",
     ]);
-    expect(routes.some((route) => route.startsWith("patch "))).toBe(false);
     expect(routes.some((route) => route.startsWith("put "))).toBe(false);
   });
 
@@ -128,5 +129,17 @@ describe("test-scenario routes", () => {
 
       expect(route?.route?.stack.some((entry) => entry.handle === controller)).toBe(true);
     }
+  });
+
+  it("hands PATCH to the update controller after JWT authentication", () => {
+    const route = routeLayers().find((layer) => {
+      const metadata = layer.route;
+      return metadata &&
+        `${Object.keys(metadata.methods)[0]} ${metadata.path}` ===
+          "patch /v2/test-scenarios/:scenarioId";
+    });
+
+    expect(route?.route?.stack.some((entry) => entry.handle === authMiddleware)).toBe(true);
+    expect(route?.route?.stack.some((entry) => entry.handle === controllerMocks.update)).toBe(true);
   });
 });

--- a/__tests__/routes/test-scenarios.test.ts
+++ b/__tests__/routes/test-scenarios.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { jest } from "@jest/globals";
+
+const authMiddlewareMock = jest.fn();
+const controllerMocks = {
+  create: jest.fn(),
+  list: jest.fn(),
+  getById: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock("@/middleware/authMiddleware", () => ({
+  authMiddleware: authMiddlewareMock,
+}));
+
+jest.mock("@/controllers/testScenarioController", () => ({
+  testScenarioController: controllerMocks,
+}));
+
+import router from "@/routes/test-scenarios";
+import { authMiddleware } from "@/middleware/authMiddleware";
+
+interface RouteLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: Array<{ handle: unknown }>;
+  };
+}
+
+const routeLayers = (): RouteLayer[] =>
+  (router as unknown as { stack: RouteLayer[] }).stack;
+
+describe("test-scenario routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers exactly create, list, detail, and delete operations", () => {
+    const routes = routeLayers()
+      .filter((layer) => layer.route)
+      .map((layer) => {
+        const route = layer.route;
+        if (!route) throw new Error("Route metadata is missing");
+        return `${Object.keys(route.methods)[0]} ${route.path}`;
+      });
+
+    expect(routes).toEqual([
+      "post /v2/test-scenarios",
+      "get /v2/test-scenarios",
+      "get /v2/test-scenarios/:scenarioId",
+      "delete /v2/test-scenarios/:scenarioId",
+    ]);
+    expect(routes.some((route) => route.startsWith("patch "))).toBe(false);
+    expect(routes.some((route) => route.startsWith("put "))).toBe(false);
+  });
+
+  it("puts JWT authentication before every scenario controller", () => {
+    for (const layer of routeLayers()) {
+      const route = layer.route;
+      if (!route) continue;
+
+      expect(route.stack.some((entry) => entry.handle === authMiddleware)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("mounts the router in the central API router", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "src/routes/index.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('import testScenarios from "@/routes/test-scenarios"');
+    expect(source).toContain("router.use(testScenarios)");
+  });
+
+  it("does not introduce MCP operations", () => {
+    expect(controllerMocks).not.toHaveProperty("mcp");
+  });
+});

--- a/__tests__/schemas/testScenarioIntegrationSchemas.test.ts
+++ b/__tests__/schemas/testScenarioIntegrationSchemas.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  testScenarioEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema,
+  testScenarioSpecLinkListQuerySchema,
+} from "@/schemas/testScenarioIntegrationSchemas";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const specId = "22222222-2222-2222-2222-222222222222";
+
+describe("test scenario integration schemas", () => {
+  it("accepts link input and defaults paginated queries", () => {
+    expect(testScenarioSpecLinkBodySchema.parse({ specId })).toEqual({ specId });
+    expect(testScenarioSpecLinkListQuerySchema.parse({ projectId })).toEqual({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+    expect(testScenarioEvidenceQuerySchema.parse({ projectId })).toEqual({
+      projectId,
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("coerces valid pagination and rejects invalid or oversized values", () => {
+    expect(
+      testScenarioEvidenceQuerySchema.parse({
+        projectId,
+        page: "2",
+        limit: "100",
+      }),
+    ).toEqual({ projectId, page: 2, limit: 100 });
+    expect(() =>
+      testScenarioEvidenceQuerySchema.parse({ projectId, page: "0" }),
+    ).toThrow();
+    expect(() =>
+      testScenarioEvidenceQuerySchema.parse({ projectId, limit: "101" }),
+    ).toThrow();
+    expect(() =>
+      testScenarioSpecLinkBodySchema.parse({ specId: "not-a-uuid" }),
+    ).toThrow();
+  });
+});

--- a/__tests__/schemas/testScenarioSchemas.test.ts
+++ b/__tests__/schemas/testScenarioSchemas.test.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { updateTestScenarioSchema } from "@/schemas/testScenarioSchemas";
+
+describe("update test scenario schema", () => {
+  it.each([
+    [{ title: "  Updated title  " }, { title: "Updated title" }],
+    [{ contentMd: "  # Updated\n" }, { contentMd: "  # Updated\n" }],
+    [
+      { title: " Updated ", contentMd: "# Updated" },
+      { title: "Updated", contentMd: "# Updated" },
+    ],
+  ])("accepts %j", (body, expected) => {
+    expect(updateTestScenarioSchema.parse(body)).toEqual(expected);
+  });
+
+  it.each([
+    {},
+    { title: "" },
+    { title: "   " },
+    { contentMd: "" },
+    { title: null },
+    { contentMd: null },
+    { title: 123 },
+    { contentMd: 123 },
+    { unknown: "value" },
+    { title: "Updated", unknown: "value" },
+    { projectId: "11111111-1111-1111-1111-111111111111" },
+    { title: "Updated", createdById: "22222222-2222-2222-2222-222222222222" },
+    { contentMd: "# Updated", createdAt: "2026-01-01T00:00:00.000Z" },
+    { contentMd: "# Updated", updatedAt: "2026-01-01T00:00:00.000Z" },
+    null,
+  ])("rejects %j", (body) => {
+    expect(updateTestScenarioSchema.safeParse(body).success).toBe(false);
+  });
+});

--- a/__tests__/services/testScenarioIntegrationService.test.ts
+++ b/__tests__/services/testScenarioIntegrationService.test.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+import {
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
+
+const scenarioFindByIdMock = jest.fn<() => Promise<unknown>>();
+const specFindByIdMock = jest.fn<() => Promise<unknown>>();
+const linkCreateMock = jest.fn<() => Promise<unknown>>();
+const linkFindLinkedSpecsMock = jest.fn<() => Promise<unknown>>();
+const linkCountMock = jest.fn<() => Promise<unknown>>();
+const linkFindIdsMock = jest.fn<() => Promise<unknown>>();
+const linkDeleteMock = jest.fn<() => Promise<unknown>>();
+const resultEvidenceMock = jest.fn<() => Promise<unknown>>();
+const issueEvidenceMock = jest.fn<() => Promise<unknown>>();
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: { findById: scenarioFindByIdMock },
+}));
+jest.mock("@/models/specModel", () => ({
+  specModel: { findById: specFindByIdMock },
+}));
+jest.mock("@/models/testScenarioSpecLinkModel", () => ({
+  testScenarioSpecLinkModel: {
+    create: linkCreateMock,
+    findLinkedSpecs: linkFindLinkedSpecsMock,
+    countLinkedSpecs: linkCountMock,
+    findLinkedSpecIds: linkFindIdsMock,
+    delete: linkDeleteMock,
+  },
+}));
+jest.mock("@/services/resultService", () => ({
+  resultService: { getResultsBySpecRecordIds: resultEvidenceMock },
+}));
+jest.mock("@/services/issueService", () => ({
+  issueService: { getObservedIssuesBySpecRecordIds: issueEvidenceMock },
+}));
+
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const scenarioId = "22222222-2222-2222-2222-222222222222";
+const specId = "33333333-3333-3333-3333-333333333333";
+const scenario = {
+  id: scenarioId,
+  projectId,
+  createdById: "44444444-4444-4444-4444-444444444444",
+  title: "Scenario",
+  contentMd: "# Scenario",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+const spec = {
+  id: specId,
+  projectId,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  key: "spec-1",
+  file: "login.spec.ts",
+  title: "Login",
+  tags: ["smoke"],
+  annotations: [],
+};
+
+describe("testScenarioIntegrationService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scenarioFindByIdMock.mockResolvedValue(scenario);
+    specFindByIdMock.mockResolvedValue(spec);
+    linkCreateMock.mockResolvedValue({ testScenarioId: scenarioId, specId });
+    linkFindLinkedSpecsMock.mockResolvedValue([{ spec }]);
+    linkCountMock.mockResolvedValue(1);
+    linkFindIdsMock.mockResolvedValue([specId]);
+    linkDeleteMock.mockResolvedValue(1);
+    resultEvidenceMock.mockResolvedValue({ results: [], total: 0 });
+    issueEvidenceMock.mockResolvedValue({ issues: [], total: 0 });
+  });
+
+  it("validates both endpoints in one project before creating a link", async () => {
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).resolves.toEqual({ scenarioId, specId });
+
+    expect(scenarioFindByIdMock).toHaveBeenCalledWith(scenarioId, projectId);
+    expect(specFindByIdMock).toHaveBeenCalledWith(specId, projectId);
+    expect(linkCreateMock).toHaveBeenCalledWith({
+      testScenarioId: scenarioId,
+      specId,
+    });
+  });
+
+  it("maps a database uniqueness race to the typed conflict error", async () => {
+    linkCreateMock.mockRejectedValue({ code: "P2002" });
+
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkConflictError);
+  });
+
+  it("rejects cross-project links before persistence", async () => {
+    specFindByIdMock.mockResolvedValue(null);
+
+    await expect(
+      testScenarioIntegrationService.addSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkNotFoundError);
+    expect(linkCreateMock).not.toHaveBeenCalled();
+    expect(specFindByIdMock).toHaveBeenCalledWith(specId, projectId);
+  });
+
+  it("lists normalized Specs with stable pagination metadata", async () => {
+    const result = await testScenarioIntegrationService.listSpecLinks({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 1,
+    });
+
+    expect(result).toEqual({
+      scenarioId,
+      projectId,
+      specs: [{ ...spec, tags: ["smoke"], annotations: [] }],
+      total: 1,
+      page: 2,
+      limit: 1,
+      totalPages: 1,
+    });
+    expect(linkFindLinkedSpecsMock).toHaveBeenCalledWith(
+      scenarioId,
+      projectId,
+      2,
+      1,
+    );
+  });
+
+  it("removes only an existing link and reports missing links as not found", async () => {
+    await expect(
+      testScenarioIntegrationService.removeSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).resolves.toBeUndefined();
+    expect(linkDeleteMock).toHaveBeenCalledWith(scenarioId, specId);
+
+    linkDeleteMock.mockResolvedValue(0);
+    await expect(
+      testScenarioIntegrationService.removeSpecLink({
+        scenarioId,
+        specId,
+        projectId,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioSpecLinkNotFoundError);
+  });
+
+  it("aggregates independently paginated Result evidence across linked Specs", async () => {
+    resultEvidenceMock.mockResolvedValue({ results: [{ id: "result-1" }], total: 3 });
+
+    const result = await testScenarioIntegrationService.getResults({
+      scenarioId,
+      projectId,
+      page: 2,
+      limit: 2,
+    });
+
+    expect(result).toEqual({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 1,
+      results: [{ id: "result-1" }],
+      total: 3,
+      page: 2,
+      limit: 2,
+      totalPages: 2,
+    });
+    expect(resultEvidenceMock).toHaveBeenCalledWith({
+      projectId,
+      specRecordIds: [specId],
+      page: 2,
+      limit: 2,
+    });
+  });
+
+  it("returns a valid empty Issue envelope for unlinked scenarios", async () => {
+    linkFindIdsMock.mockResolvedValue([]);
+    linkCountMock.mockResolvedValue(0);
+
+    await expect(
+      testScenarioIntegrationService.getIssues({ scenarioId, projectId }),
+    ).resolves.toEqual({
+      scenarioId,
+      projectId,
+      linkedSpecCount: 0,
+      issues: [],
+      total: 0,
+      page: 1,
+      limit: 30,
+      totalPages: 0,
+    });
+    expect(issueEvidenceMock).toHaveBeenCalledWith({
+      projectId,
+      specRecordIds: [],
+      page: 1,
+      limit: 30,
+    });
+  });
+
+  it("returns 404 semantics for an unknown scenario context", async () => {
+    scenarioFindByIdMock.mockResolvedValue(null);
+
+    await expect(
+      testScenarioIntegrationService.getResults({ scenarioId, projectId }),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(linkFindIdsMock).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/testScenarioService.test.ts
+++ b/__tests__/services/testScenarioService.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+
+const mockProjectExists = jest.fn<() => Promise<boolean>>();
+const mockCreate = jest.fn<() => Promise<TestScenario>>();
+const mockFindMany = jest.fn<() => Promise<TestScenario[]>>();
+const mockCount = jest.fn<() => Promise<number>>();
+const mockFindById = jest.fn<() => Promise<TestScenario | null>>();
+const mockDelete = jest.fn<() => Promise<number>>();
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: mockProjectExists,
+  },
+}));
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    create: mockCreate,
+    findMany: mockFindMany,
+    count: mockCount,
+    findById: mockFindById,
+    delete: mockDelete,
+  },
+}));
+
+import { testScenarioService } from "@/services/testScenarioService";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+} from "@/types/testScenarios";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+const otherProjectId = "22222222-2222-2222-2222-222222222222";
+const scenario: TestScenario = {
+  id: "33333333-3333-3333-3333-333333333333",
+  projectId,
+  createdById: "44444444-4444-4444-4444-444444444444",
+  title: "Login",
+  contentMd: "# Login\n\n```ts\n  const value = '✓';\n```\n",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("testScenarioService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProjectExists.mockResolvedValue(true);
+    mockCreate.mockResolvedValue(scenario);
+    mockFindMany.mockResolvedValue([scenario]);
+    mockCount.mockResolvedValue(1);
+    mockFindById.mockResolvedValue(scenario);
+    mockDelete.mockResolvedValue(1);
+  });
+
+  it("trims titles and preserves Markdown exactly", async () => {
+    const contentMd = "# Heading\n\n  indented ✓\n";
+
+    const result = await testScenarioService.createScenario({
+      projectId,
+      title: "  Scenario title  ",
+      contentMd,
+      createdById: scenario.createdById,
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      projectId,
+      title: "Scenario title",
+      contentMd,
+      createdById: scenario.createdById,
+    });
+    expect(result).toBe(scenario);
+  });
+
+  it("rejects creation for an unknown project before persistence", async () => {
+    mockProjectExists.mockResolvedValue(false);
+
+    await expect(
+      testScenarioService.createScenario({
+      projectId: otherProjectId,
+      title: "Scenario",
+      contentMd: "content",
+      createdById: scenario.createdById,
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns stable pagination metadata and forwards page offsets", async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(61);
+
+    const result = await testScenarioService.listScenarios({
+      projectId,
+      page: 3,
+      limit: 30,
+    });
+
+    expect(mockFindMany).toHaveBeenCalledWith(projectId, 3, 30);
+    expect(mockCount).toHaveBeenCalledWith(projectId);
+    expect(result).toEqual({
+      scenarios: [],
+      total: 61,
+      page: 3,
+      limit: 30,
+      totalPages: 3,
+    });
+  });
+
+  it("returns an empty page for an unknown project without disclosing records", async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+
+    const result = await testScenarioService.listScenarios({
+      projectId: otherProjectId,
+    });
+
+    expect(result.scenarios).toEqual([]);
+    expect(result.totalPages).toBe(0);
+    expect(mockFindMany).toHaveBeenCalledWith(otherProjectId, 1, 30);
+  });
+
+  it("classifies cross-project detail access as not found", async () => {
+    mockFindById.mockResolvedValue(null);
+
+    await expect(
+      testScenarioService.getScenarioById(scenario.id, otherProjectId),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(mockFindById).toHaveBeenCalledWith(scenario.id, otherProjectId);
+  });
+
+  it("classifies invalid service pagination as validation failure", async () => {
+    await expect(
+      testScenarioService.listScenarios({ projectId, page: 0, limit: 30 }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+  });
+
+  it("deletes only the requested project scenario", async () => {
+    await testScenarioService.deleteScenario(scenario.id, projectId);
+
+    expect(mockDelete).toHaveBeenCalledWith(scenario.id, projectId);
+  });
+
+  it("does not report deletion success when the composite identity is absent", async () => {
+    mockDelete.mockResolvedValue(0);
+
+    await expect(
+      testScenarioService.deleteScenario(scenario.id, otherProjectId),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+  });
+});

--- a/__tests__/services/testScenarioService.test.ts
+++ b/__tests__/services/testScenarioService.test.ts
@@ -10,6 +10,13 @@ const mockCreate = jest.fn<() => Promise<TestScenario>>();
 const mockFindMany = jest.fn<() => Promise<TestScenario[]>>();
 const mockCount = jest.fn<() => Promise<number>>();
 const mockFindById = jest.fn<() => Promise<TestScenario | null>>();
+const mockUpdate = jest.fn<
+  (
+    scenarioId: string,
+    projectId: string,
+    data: { title?: string; contentMd?: string },
+  ) => Promise<TestScenario | null>
+>();
 const mockDelete = jest.fn<() => Promise<number>>();
 
 jest.mock("@/models/projectModel", () => ({
@@ -24,6 +31,7 @@ jest.mock("@/models/testScenarioModel", () => ({
     findMany: mockFindMany,
     count: mockCount,
     findById: mockFindById,
+    update: mockUpdate,
     delete: mockDelete,
   },
 }));
@@ -54,6 +62,7 @@ describe("testScenarioService", () => {
     mockFindMany.mockResolvedValue([scenario]);
     mockCount.mockResolvedValue(1);
     mockFindById.mockResolvedValue(scenario);
+    mockUpdate.mockResolvedValue(scenario);
     mockDelete.mockResolvedValue(1);
   });
 
@@ -143,6 +152,121 @@ describe("testScenarioService", () => {
     await testScenarioService.deleteScenario(scenario.id, projectId);
 
     expect(mockDelete).toHaveBeenCalledWith(scenario.id, projectId);
+  });
+
+  it("updates only the title and trims it", async () => {
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      title: "  Updated title  ",
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      title: "Updated title",
+    });
+  });
+
+  it("updates only Markdown without changing its source text", async () => {
+    const contentMd = "  # Updated\n\n  ✓\n";
+
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      contentMd,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      contentMd,
+    });
+  });
+
+  it("updates title and Markdown together", async () => {
+    const contentMd = "# Combined";
+
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      title: "  Combined title ",
+      contentMd,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      title: "Combined title",
+      contentMd,
+    });
+  });
+
+  it("allows an intentional no-op value update", async () => {
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      title: scenario.title,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      title: scenario.title,
+    });
+  });
+
+  it("uses the value returned by the later last-write-wins update", async () => {
+    const first = { ...scenario, title: "First write" };
+    const second = { ...scenario, title: "Last write" };
+    mockUpdate.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        title: "First write",
+      }),
+    ).resolves.toBe(first);
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        title: "Last write",
+      }),
+    ).resolves.toBe(second);
+    expect(mockUpdate.mock.calls.map((call) => call[2])).toEqual([
+      { title: "First write" },
+      { title: "Last write" },
+    ]);
+  });
+
+  it("rejects an empty update and invalid field values before persistence", async () => {
+    await expect(
+      testScenarioService.updateScenario({ scenarioId: scenario.id, projectId }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        title: "   ",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        contentMd: "",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("maps a cross-project update miss to the existing not-found error", async () => {
+    mockUpdate.mockResolvedValue(null);
+
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId: otherProjectId,
+        contentMd: "# Never applied",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioNotFoundError);
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, otherProjectId, {
+      contentMd: "# Never applied",
+    });
   });
 
   it("does not report deletion success when the composite identity is absent", async () => {

--- a/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
@@ -1,0 +1,343 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+
+interface ScenarioRecord {
+  id: string;
+  projectId: string;
+}
+
+interface SpecRecord {
+  id: string;
+  projectId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  key: string;
+  file: string;
+  title: string;
+  tags: string[];
+  annotations: unknown[];
+}
+
+interface LinkRecord {
+  testScenarioId: string;
+  specId: string;
+}
+
+const projectA = "11111111-1111-1111-1111-111111111111";
+const scenarioA = "33333333-3333-3333-3333-333333333333";
+const scenarioB = "44444444-4444-4444-4444-444444444444";
+const specA = "55555555-5555-5555-5555-555555555555";
+const specB = "66666666-6666-6666-6666-666666666666";
+
+const scenarios: ScenarioRecord[] = [
+  { id: scenarioA, projectId: projectA },
+  { id: scenarioB, projectId: projectA },
+];
+const specs: SpecRecord[] = [
+  {
+    id: specA,
+    projectId: projectA,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    key: "spec-a",
+    file: "a.spec.ts",
+    title: "A",
+    tags: [],
+    annotations: [],
+  },
+  {
+    id: specB,
+    projectId: projectA,
+    createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    key: "spec-b",
+    file: "b.spec.ts",
+    title: "B",
+    tags: [],
+    annotations: [],
+  },
+];
+const links: LinkRecord[] = [];
+const resultEvidence = [
+  { id: "result-a", specId: specA, startTime: new Date("2026-01-01T00:00:00.000Z") },
+  { id: "result-b", specId: specB, startTime: new Date("2026-01-02T00:00:00.000Z") },
+];
+const resultErrors = [
+  { id: "error-a", resultId: "result-a" },
+  { id: "error-b", resultId: "result-b" },
+];
+const assumptions = [
+  { id: "assumption-a", resultErrorId: "error-a", issueId: "issue-shared" },
+  { id: "assumption-b", resultErrorId: "error-b", issueId: "issue-b" },
+];
+const issueEvidence = [
+  { id: "issue-shared", specIds: [specA, specB], createdAt: new Date("2026-01-01T00:00:00.000Z") },
+  { id: "issue-b", specIds: [specB], createdAt: new Date("2026-01-03T00:00:00.000Z") },
+];
+
+const scenarioFindByIdMock = jest.fn<
+  (id: string, projectId: string) => Promise<ScenarioRecord | null>
+>();
+const scenarioDeleteMock = jest.fn<
+  (id: string, projectId: string) => Promise<number>
+>();
+const specFindByIdMock = jest.fn<
+  (id: string, projectId: string) => Promise<SpecRecord | null>
+>();
+const specDeleteMock = jest.fn<(id: string, projectId: string) => Promise<void>>();
+const linkCreateMock = jest.fn<
+  (data: LinkRecord) => Promise<LinkRecord>
+>();
+const linkFindSpecsMock = jest.fn<
+  (scenarioId: string, projectId: string, page?: number, limit?: number) =>
+    Promise<Array<{ spec: SpecRecord }>>
+>();
+const linkCountMock = jest.fn<
+  (scenarioId: string, projectId: string) => Promise<number>
+>();
+const linkFindIdsMock = jest.fn<
+  (scenarioId: string, projectId: string) => Promise<string[]>
+>();
+const linkDeleteMock = jest.fn<
+  (scenarioId: string, specId: string) => Promise<number>
+>();
+const resultEvidenceMock = jest.fn<
+  (params: {
+    projectId: string;
+    specRecordIds: string[];
+    page: number;
+    limit: number;
+  }) => Promise<{ results: Array<{ id: string; specId: string; startTime: Date }>; total: number }>
+>();
+const issueEvidenceMock = jest.fn<
+  (params: {
+    projectId: string;
+    specRecordIds: string[];
+    page: number;
+    limit: number;
+  }) => Promise<{ issues: Array<{ id: string; specIds: string[]; createdAt: Date }>; total: number }>
+>();
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    findById: scenarioFindByIdMock,
+    delete: scenarioDeleteMock,
+  },
+}));
+jest.mock("@/models/specModel", () => ({
+  specModel: {
+    findById: specFindByIdMock,
+    delete: specDeleteMock,
+  },
+}));
+jest.mock("@/models/testScenarioSpecLinkModel", () => ({
+  testScenarioSpecLinkModel: {
+    create: linkCreateMock,
+    findLinkedSpecs: linkFindSpecsMock,
+    countLinkedSpecs: linkCountMock,
+    findLinkedSpecIds: linkFindIdsMock,
+    delete: linkDeleteMock,
+  },
+}));
+jest.mock("@/services/resultService", () => ({
+  resultService: { getResultsBySpecRecordIds: resultEvidenceMock },
+}));
+jest.mock("@/services/issueService", () => ({
+  issueService: { getObservedIssuesBySpecRecordIds: issueEvidenceMock },
+}));
+
+import { specService } from "@/services/specService";
+import { testScenarioService } from "@/services/testScenarioService";
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
+
+describe("test scenario execution evidence workflow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    links.length = 0;
+    if (!scenarios.some((scenario) => scenario.id === scenarioA)) {
+      scenarios.push({ id: scenarioA, projectId: projectA });
+    }
+    if (!scenarios.some((scenario) => scenario.id === scenarioB)) {
+      scenarios.push({ id: scenarioB, projectId: projectA });
+    }
+    if (!specs.some((spec) => spec.id === specA)) {
+      specs.push({
+        id: specA,
+        projectId: projectA,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        key: "spec-a",
+        file: "a.spec.ts",
+        title: "A",
+        tags: [],
+        annotations: [],
+      });
+    }
+    if (!specs.some((spec) => spec.id === specB)) {
+      specs.push({
+        id: specB,
+        projectId: projectA,
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        key: "spec-b",
+        file: "b.spec.ts",
+        title: "B",
+        tags: [],
+        annotations: [],
+      });
+    }
+    scenarios.sort((left, right) => left.id.localeCompare(right.id));
+    specs.sort((left, right) => left.id.localeCompare(right.id));
+    scenarioFindByIdMock.mockImplementation(async (id, projectId) =>
+      scenarios.find((scenario) => scenario.id === id && scenario.projectId === projectId) ?? null,
+    );
+    scenarioDeleteMock.mockImplementation(async (id, projectId) => {
+      const index = scenarios.findIndex(
+        (scenario) => scenario.id === id && scenario.projectId === projectId,
+      );
+      if (index === -1) return 0;
+      scenarios.splice(index, 1);
+      links.splice(0, links.length, ...links.filter((link) => link.testScenarioId !== id));
+      return 1;
+    });
+    specFindByIdMock.mockImplementation(async (id, projectId) =>
+      specs.find((spec) => spec.id === id && spec.projectId === projectId) ?? null,
+    );
+    specDeleteMock.mockImplementation(async (id, projectId) => {
+      const index = specs.findIndex(
+        (spec) => spec.id === id && spec.projectId === projectId,
+      );
+      if (index === -1) throw new Error(`Spec with ID ${id} not found`);
+      specs.splice(index, 1);
+      links.splice(0, links.length, ...links.filter((link) => link.specId !== id));
+    });
+    linkCreateMock.mockImplementation(async (data) => {
+      if (links.some((link) => link.testScenarioId === data.testScenarioId && link.specId === data.specId)) {
+        throw { code: "P2002" } as unknown;
+      }
+      links.push(data);
+      return data;
+    });
+    linkFindSpecsMock.mockImplementation(async (scenarioId: string, projectId: string, page = 1, limit = 30) => {
+      const matching = links
+        .filter((link) => link.testScenarioId === scenarioId)
+        .map((link) => ({ spec: specs.find((spec) => spec.id === link.specId) }))
+        .filter((link): link is { spec: SpecRecord } => link.spec?.projectId === projectId)
+        .sort((left, right) => right.spec.createdAt.getTime() - left.spec.createdAt.getTime());
+      return matching.slice((page - 1) * limit, page * limit);
+    });
+    linkCountMock.mockImplementation(async (scenarioId: string, projectId: string) =>
+      links.filter((link) => link.testScenarioId === scenarioId && specs.some((spec) => spec.id === link.specId && spec.projectId === projectId)).length,
+    );
+    linkFindIdsMock.mockImplementation(async (scenarioId: string, projectId: string) =>
+      links
+        .filter((link) => link.testScenarioId === scenarioId && specs.some((spec) => spec.id === link.specId && spec.projectId === projectId))
+        .map((link) => link.specId),
+    );
+    linkDeleteMock.mockImplementation(async (scenarioId: string, specId: string) => {
+      const index = links.findIndex((link) => link.testScenarioId === scenarioId && link.specId === specId);
+      if (index === -1) return 0;
+      links.splice(index, 1);
+      return 1;
+    });
+    resultEvidenceMock.mockImplementation(async ({ projectId, specRecordIds, page, limit }: { projectId: string; specRecordIds: string[]; page: number; limit: number }) => {
+      const matching = resultEvidence.filter((result) => specRecordIds.includes(result.specId) && specs.some((spec) => spec.id === result.specId && spec.projectId === projectId));
+      const sorted = [...matching].sort((left, right) => right.startTime.getTime() - left.startTime.getTime() || right.id.localeCompare(left.id));
+      return { results: sorted.slice((page - 1) * limit, page * limit), total: sorted.length };
+    });
+    issueEvidenceMock.mockImplementation(async ({ projectId, specRecordIds, page, limit }: { projectId: string; specRecordIds: string[]; page: number; limit: number }) => {
+      const matching = issueEvidence.filter((issue) => issue.specIds.some((id) => specRecordIds.includes(id)) && specs.some((spec) => issue.specIds.includes(spec.id) && spec.projectId === projectId));
+      const unique = [...new Map(matching.map((issue) => [issue.id, issue])).values()]
+        .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime() || right.id.localeCompare(left.id));
+      return { issues: unique.slice((page - 1) * limit, page * limit), total: unique.length };
+    });
+  });
+
+  it("links multiple scenarios and Specs with independent Result and Issue pagination", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specB, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioB, specId: specB, projectId: projectA });
+
+    const resultPageOne = await testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA, page: 1, limit: 1 });
+    const resultPageTwo = await testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA, page: 2, limit: 1 });
+    const issuePageOne = await testScenarioIntegrationService.getIssues({ scenarioId: scenarioA, projectId: projectA, page: 1, limit: 1 });
+    const issuePageTwo = await testScenarioIntegrationService.getIssues({ scenarioId: scenarioA, projectId: projectA, page: 2, limit: 1 });
+
+    expect(resultPageOne.linkedSpecCount).toBe(2);
+    expect(resultPageOne.total).toBe(2);
+    expect(resultPageOne.results[0]?.id).toBe("result-b");
+    expect(resultPageTwo.results[0]?.id).toBe("result-a");
+    expect(issuePageOne.total).toBe(2);
+    expect(issuePageOne.issues[0]?.id).toBe("issue-b");
+    expect(issuePageTwo.issues[0]?.id).toBe("issue-shared");
+
+    const scenarioBResults = await testScenarioIntegrationService.getResults({ scenarioId: scenarioB, projectId: projectA });
+    expect(scenarioBResults.linkedSpecCount).toBe(1);
+    expect(scenarioBResults.results.map((result) => result.id)).toEqual(["result-b"]);
+  });
+
+  it("unlinks only the association and preserves endpoints and evidence", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specB, projectId: projectA });
+    const endpointSnapshot = {
+      scenarios: scenarios.map((scenario) => ({ ...scenario })),
+      specs: specs.map((spec) => ({ ...spec })),
+      results: resultEvidence.map((result) => ({ ...result })),
+      resultErrors: resultErrors.map((error) => ({ ...error })),
+      assumptions: assumptions.map((assumption) => ({ ...assumption })),
+      issues: issueEvidence.map((issue) => ({ ...issue })),
+    };
+
+    await testScenarioIntegrationService.removeSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+
+    expect(scenarios).toEqual(endpointSnapshot.scenarios);
+    expect(specs).toEqual(endpointSnapshot.specs);
+    expect(resultEvidence).toEqual(endpointSnapshot.results);
+    expect(resultErrors).toEqual(endpointSnapshot.resultErrors);
+    expect(assumptions).toEqual(endpointSnapshot.assumptions);
+    expect(issueEvidence).toEqual(endpointSnapshot.issues);
+    await expect(testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA })).resolves.toEqual(expect.objectContaining({ linkedSpecCount: 1, total: 1 }));
+  });
+
+  it("removes scenario links while preserving Specs and evidence on scenario deletion", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    const specsSnapshot = specs.map((spec) => ({ ...spec }));
+    const evidenceSnapshot = resultEvidence.map((result) => ({ ...result }));
+    const resultErrorsSnapshot = resultErrors.map((error) => ({ ...error }));
+    const assumptionsSnapshot = assumptions.map((assumption) => ({ ...assumption }));
+
+    await testScenarioService.deleteScenario(scenarioA, projectA);
+
+    expect(scenarios.some((scenario) => scenario.id === scenarioA)).toBe(false);
+    expect(links).toEqual([]);
+    expect(specs).toEqual(specsSnapshot);
+    expect(resultEvidence).toEqual(evidenceSnapshot);
+    expect(resultErrors).toEqual(resultErrorsSnapshot);
+    expect(assumptions).toEqual(assumptionsSnapshot);
+  });
+
+  it("removes Spec links while preserving linked scenarios on Spec deletion", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioB, specId: specB, projectId: projectA });
+
+    await specService.deleteSpec(specA, projectA);
+
+    expect(scenarios).toEqual([
+      { id: scenarioA, projectId: projectA },
+      { id: scenarioB, projectId: projectA },
+    ]);
+    expect(links).toEqual([{ testScenarioId: scenarioB, specId: specB }]);
+    expect(resultEvidence).toHaveLength(2);
+    expect(resultErrors).toHaveLength(2);
+    expect(assumptions).toHaveLength(2);
+    expect(issueEvidence).toHaveLength(2);
+  });
+});

--- a/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioIntegrationWorkflow.test.ts
@@ -84,6 +84,13 @@ const scenarioFindByIdMock = jest.fn<
 const scenarioDeleteMock = jest.fn<
   (id: string, projectId: string) => Promise<number>
 >();
+const scenarioUpdateMock = jest.fn<
+  (
+    id: string,
+    projectId: string,
+    data: { title?: string; contentMd?: string },
+  ) => Promise<ScenarioRecord | null>
+>();
 const specFindByIdMock = jest.fn<
   (id: string, projectId: string) => Promise<SpecRecord | null>
 >();
@@ -129,6 +136,7 @@ jest.mock("@/models/projectModel", () => ({
 jest.mock("@/models/testScenarioModel", () => ({
   testScenarioModel: {
     findById: scenarioFindByIdMock,
+    update: scenarioUpdateMock,
     delete: scenarioDeleteMock,
   },
 }));
@@ -197,6 +205,9 @@ describe("test scenario execution evidence workflow", () => {
     scenarios.sort((left, right) => left.id.localeCompare(right.id));
     specs.sort((left, right) => left.id.localeCompare(right.id));
     scenarioFindByIdMock.mockImplementation(async (id, projectId) =>
+      scenarios.find((scenario) => scenario.id === id && scenario.projectId === projectId) ?? null,
+    );
+    scenarioUpdateMock.mockImplementation(async (id, projectId) =>
       scenarios.find((scenario) => scenario.id === id && scenario.projectId === projectId) ?? null,
     );
     scenarioDeleteMock.mockImplementation(async (id, projectId) => {
@@ -305,6 +316,45 @@ describe("test scenario execution evidence workflow", () => {
     expect(assumptions).toEqual(endpointSnapshot.assumptions);
     expect(issueEvidence).toEqual(endpointSnapshot.issues);
     await expect(testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA })).resolves.toEqual(expect.objectContaining({ linkedSpecCount: 1, total: 1 }));
+  });
+
+  it("preserves Spec links and derived evidence when scenario content changes", async () => {
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specA, projectId: projectA });
+    await testScenarioIntegrationService.addSpecLink({ scenarioId: scenarioA, specId: specB, projectId: projectA });
+    const snapshot = {
+      scenarios: scenarios.map((scenario) => ({ ...scenario })),
+      links: links.map((link) => ({ ...link })),
+      specs: specs.map((spec) => ({ ...spec })),
+      results: resultEvidence.map((result) => ({ ...result })),
+      resultErrors: resultErrors.map((error) => ({ ...error })),
+      assumptions: assumptions.map((assumption) => ({ ...assumption })),
+      issues: issueEvidence.map((issue) => ({ ...issue })),
+    };
+
+    await testScenarioService.updateScenario({
+      scenarioId: scenarioA,
+      projectId: projectA,
+      title: "Updated title",
+    });
+    await testScenarioService.updateScenario({
+      scenarioId: scenarioA,
+      projectId: projectA,
+      contentMd: "# Updated Markdown",
+    });
+
+    expect(scenarios).toEqual(snapshot.scenarios);
+    expect(links).toEqual(snapshot.links);
+    expect(specs).toEqual(snapshot.specs);
+    expect(resultEvidence).toEqual(snapshot.results);
+    expect(resultErrors).toEqual(snapshot.resultErrors);
+    expect(assumptions).toEqual(snapshot.assumptions);
+    expect(issueEvidence).toEqual(snapshot.issues);
+    await expect(
+      testScenarioIntegrationService.getResults({ scenarioId: scenarioA, projectId: projectA }),
+    ).resolves.toEqual(expect.objectContaining({ linkedSpecCount: 2, total: 2 }));
+    await expect(
+      testScenarioIntegrationService.getIssues({ scenarioId: scenarioA, projectId: projectA }),
+    ).resolves.toEqual(expect.objectContaining({ linkedSpecCount: 2, total: 2 }));
   });
 
   it("removes scenario links while preserving Specs and evidence on scenario deletion", async () => {

--- a/__tests__/test-scenarios/testScenarioWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioWorkflow.test.ts
@@ -1,0 +1,185 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import "@/test-utils/testEnv";
+import { jest } from "@jest/globals";
+import type { TestScenario } from "@prisma/client";
+import { executeController } from "@/test-utils/httpMocks";
+
+const mockProjects = new Set<string>();
+const mockScenarios: TestScenario[] = [];
+let mockNextId = 0;
+
+jest.mock("@/models/projectModel", () => ({
+  projectModel: {
+    exists: jest.fn((projectId: string) =>
+      Promise.resolve(mockProjects.has(projectId)),
+    ),
+  },
+}));
+
+jest.mock("@/models/testScenarioModel", () => ({
+  testScenarioModel: {
+    create: jest.fn((data: {
+      projectId: string;
+      title: string;
+      contentMd: string;
+      createdById: string;
+    }) => {
+      mockNextId += 1;
+      const scenario: TestScenario = {
+        id: `00000000-0000-0000-0000-${String(mockNextId).padStart(12, "0")}`,
+        projectId: data.projectId,
+        createdById: data.createdById,
+        title: data.title,
+        contentMd: data.contentMd,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      };
+      mockScenarios.push(scenario);
+      return Promise.resolve(scenario);
+    }),
+    findMany: jest.fn(
+      (projectId: string, pageInput?: number, limitInput?: number) => {
+        const page = pageInput ?? 1;
+        const limit = limitInput ?? 30;
+      const matching = mockScenarios
+        .filter((scenario) => scenario.projectId === projectId)
+        .sort((left, right) => right.id.localeCompare(left.id));
+      const start = (page - 1) * limit;
+      return Promise.resolve(matching.slice(start, start + limit));
+      },
+    ),
+    count: jest.fn((projectId: string) =>
+      Promise.resolve(
+        mockScenarios.filter((scenario) => scenario.projectId === projectId)
+          .length,
+      ),
+    ),
+    findById: jest.fn((id: string, projectId: string) =>
+      Promise.resolve(
+        mockScenarios.find(
+          (scenario) => scenario.id === id && scenario.projectId === projectId,
+        ) ?? null,
+      ),
+    ),
+    delete: jest.fn((id: string, projectId: string) => {
+      const index = mockScenarios.findIndex(
+        (scenario) => scenario.id === id && scenario.projectId === projectId,
+      );
+      if (index === -1) return Promise.resolve(0);
+      mockScenarios.splice(index, 1);
+      return Promise.resolve(1);
+    }),
+  },
+}));
+
+import { testScenarioController } from "@/controllers/testScenarioController";
+
+const projectA = "11111111-1111-1111-1111-111111111111";
+const projectB = "22222222-2222-2222-2222-222222222222";
+const creatorId = "33333333-3333-3333-3333-333333333333";
+const spoofedCreatorId = "44444444-4444-4444-4444-444444444444";
+const authenticatedUser = {
+  id: creatorId,
+  name: "Scenario Creator",
+  email: "creator@example.com",
+  status: "active",
+  role: "member",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+} as const;
+
+describe("test-scenario project-isolated workflow", () => {
+  beforeEach(() => {
+    mockProjects.clear();
+    mockScenarios.length = 0;
+    mockNextId = 0;
+    mockProjects.add(projectA);
+    mockProjects.add(projectB);
+  });
+
+  it("round-trips Markdown, paginates deterministically, and isolates projects", async () => {
+    const exactMarkdown = "# Heading\n\n  ✓ indented\n\n```ts\nconst x = 1;\n```\n";
+    const first = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: {
+        projectId: projectA,
+        title: "  First  ",
+        contentMd: exactMarkdown,
+        createdById: spoofedCreatorId,
+      },
+    });
+    const second = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: projectA, title: "Second", contentMd: "## Second" },
+    });
+    await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: projectB, title: "Other project", contentMd: "# Other" },
+    });
+
+    expect(first.statusCode).toBe(201);
+    expect((first.body as TestScenario).title).toBe("First");
+    expect((first.body as TestScenario).createdById).toBe(creatorId);
+    expect((first.body as TestScenario).createdById).not.toBe(spoofedCreatorId);
+    expect((first.body as TestScenario).contentMd).toBe(exactMarkdown);
+
+    const pageOne = await executeController(testScenarioController.list, {
+      query: { projectId: projectA, page: "1", limit: "1" },
+    });
+    expect(pageOne.body).toEqual(expect.objectContaining({
+      total: 2,
+      page: 1,
+      limit: 1,
+      totalPages: 2,
+    }));
+    expect((pageOne.body as { scenarios: TestScenario[] }).scenarios).toHaveLength(1);
+
+    const pageTwo = await executeController(testScenarioController.list, {
+      query: { projectId: projectA, page: "2", limit: "1" },
+    });
+    expect((pageTwo.body as { scenarios: TestScenario[] }).scenarios[0]?.title).toBe(
+      "First",
+    );
+
+    const scenarioId = (first.body as TestScenario).id;
+    const crossProjectDetail = await executeController(
+      testScenarioController.getById,
+      { params: { scenarioId }, query: { projectId: projectB } },
+    );
+    expect(crossProjectDetail.statusCode).toBe(404);
+
+    const crossProjectDelete = await executeController(
+      testScenarioController.delete,
+      { method: "DELETE", params: { scenarioId }, query: { projectId: projectB } },
+    );
+    expect(crossProjectDelete.statusCode).toBe(404);
+
+    const detail = await executeController(testScenarioController.getById, {
+      params: { scenarioId },
+      query: { projectId: projectA },
+    });
+    expect(detail.statusCode).toBe(200);
+    expect((detail.body as TestScenario).contentMd).toBe(exactMarkdown);
+
+    const deleteResponse = await executeController(testScenarioController.delete, {
+      method: "DELETE",
+      params: { scenarioId },
+      query: { projectId: projectA },
+    });
+    expect(deleteResponse.statusCode).toBe(204);
+
+    const remaining = await executeController(testScenarioController.list, {
+      query: { projectId: projectA },
+    });
+    expect((remaining.body as { scenarios: TestScenario[] }).scenarios).toHaveLength(1);
+    expect((remaining.body as { scenarios: TestScenario[] }).scenarios[0]?.title).toBe(
+      "Second",
+    );
+    expect(second.statusCode).toBe(201);
+  });
+});

--- a/__tests__/test-scenarios/testScenarioWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioWorkflow.test.ts
@@ -63,6 +63,23 @@ jest.mock("@/models/testScenarioModel", () => ({
         ) ?? null,
       ),
     ),
+    update: jest.fn(
+      (
+        id: string,
+        projectId: string,
+        data: { title?: string; contentMd?: string },
+      ) => {
+        const scenario = mockScenarios.find(
+          (candidate) => candidate.id === id && candidate.projectId === projectId,
+        );
+        if (!scenario) return Promise.resolve(null);
+
+        Object.assign(scenario, data, {
+          updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+        });
+        return Promise.resolve({ ...scenario });
+      },
+    ),
     delete: jest.fn((id: string, projectId: string) => {
       const index = mockScenarios.findIndex(
         (scenario) => scenario.id === id && scenario.projectId === projectId,
@@ -181,5 +198,93 @@ describe("test-scenario project-isolated workflow", () => {
       "Second",
     );
     expect(second.statusCode).toBe(201);
+  });
+
+  it("round-trips exact Markdown and preserves immutable metadata on updates", async () => {
+    const created = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: { projectId: projectA, title: "Original", contentMd: "# Original" },
+    });
+    const original = { ...(created.body as TestScenario) };
+    const exactMarkdown =
+      "# Ünïcøde heading\r\n\r\n  indented text  \r\n\r\n```typescript\r\n\tconst value = `✓`;\r\n```\r\n";
+
+    const updated = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+      body: { title: "  Revised title  ", contentMd: exactMarkdown },
+    });
+    const updatedScenario = updated.body as TestScenario;
+
+    expect(updated.statusCode).toBe(200);
+    expect(updatedScenario.title).toBe("Revised title");
+    expect(updatedScenario.contentMd).toBe(exactMarkdown);
+    expect(updatedScenario.id).toBe(original.id);
+    expect(updatedScenario.projectId).toBe(original.projectId);
+    expect(updatedScenario.createdById).toBe(original.createdById);
+    expect(updatedScenario.createdAt).toBe(original.createdAt);
+    expect(updatedScenario.updatedAt.getTime()).toBeGreaterThan(
+      original.updatedAt.getTime(),
+    );
+
+    const detail = await executeController(testScenarioController.getById, {
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+    });
+    expect((detail.body as TestScenario).contentMd).toBe(exactMarkdown);
+
+    const whitespaceOnly = " \t\r\n  ";
+    const whitespaceUpdate = await executeController(
+      testScenarioController.update,
+      {
+        method: "PATCH",
+        params: { scenarioId: original.id },
+        query: { projectId: projectA },
+        body: { contentMd: whitespaceOnly },
+      },
+    );
+    expect((whitespaceUpdate.body as TestScenario).contentMd).toBe(whitespaceOnly);
+
+    const firstWrite = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+      body: { title: "First write" },
+    });
+    const lastWrite = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+      body: { title: "Last write" },
+    });
+    expect((firstWrite.body as TestScenario).title).toBe("First write");
+    expect((lastWrite.body as TestScenario).title).toBe("Last write");
+
+    const rejected = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+      body: {},
+    });
+    expect(rejected.statusCode).toBe(400);
+
+    const crossProject = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectB },
+      body: { title: "Should not apply" },
+    });
+    expect(crossProject.statusCode).toBe(404);
+
+    const unchangedAfterRejection = await executeController(
+      testScenarioController.getById,
+      { params: { scenarioId: original.id }, query: { projectId: projectA } },
+    );
+    expect((unchangedAfterRejection.body as TestScenario).title).toBe("Last write");
+    expect((unchangedAfterRejection.body as TestScenario).contentMd).toBe(
+      whitespaceOnly,
+    );
   });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,6 +87,7 @@ export default [
       "dist/**",
       "node_modules/**",
       "backup-js-files/**",
+      ".agents/**",
       "__mocks__/**",
       "*.d.ts",
       "jest.config.ts",

--- a/openspec/changes/add-markdown-test-scenarios/.openspec.yaml
+++ b/openspec/changes/add-markdown-test-scenarios/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/add-markdown-test-scenarios/design.md
+++ b/openspec/changes/add-markdown-test-scenarios/design.md
@@ -1,0 +1,110 @@
+## Context
+
+The backend currently persists execution-imported `Spec` records, but it has no domain model for human-authored test scenarios. Issue #72 introduces that model as a deliberately independent REST-only slice. The implementation must follow the existing routes → controllers → services → models layering, use Prisma/PostgreSQL persistence, publish Zod-backed OpenAPI contracts, and retain the repository's `{ error: string }` error envelope.
+
+Projects are the existing domain boundary. Authentication establishes an active user, while most current project-scoped resources enforce context by including `projectId` in data queries rather than performing per-resource owner authorization. This change preserves those current project-access semantics and does not attempt a partial authorization redesign.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist project-owned scenarios with a title and raw Markdown source.
+- Record the authenticated creator of every scenario.
+- Expose authenticated create, paginated list, detail, and delete operations.
+- Make cross-project scenario access impossible when a scenario ID is used with a different requested project ID.
+- Preserve `contentMd` exactly after it passes request validation.
+- Provide deterministic pagination and one documented response shape.
+- Keep scenario deletion isolated from all execution and issue data.
+- Preserve successful project deletion when its project has scenarios.
+
+**Non-Goals:**
+
+- Updating scenarios or tracking revisions.
+- Rendering, parsing, sanitizing, or semantically validating Markdown.
+- Connecting scenarios to `Spec`, `Result`, `ResultError`, `Assumption`, `Issue`, or executions.
+- MCP tools, client UI, suites/folders, attachments, archive/restore, manual runs, or Git-backed storage.
+- Introducing project-owner authorization across existing APIs.
+
+## Decisions
+
+### 1. Use a separate relational model with no execution-domain links
+
+Add `TestScenario` with UUID `id`, `projectId`, and required `createdById`; string `title`; PostgreSQL text `contentMd`; and Prisma-managed `createdAt`/`updatedAt`. Add `Project.testScenarios` and a named `User.testScenariosCreated` / `TestScenario.createdBy` relation, plus indexes for project and creator access. There will be no relation to the existing `Spec` model or downstream execution and issue models.
+
+This enforces domain separation in the schema, records durable creator attribution, and makes direct scenario deletion a single-record operation. Reusing `Spec` was rejected because its uniqueness, imported metadata, and result relationships give it a different lifecycle. Creator attribution is required because scenario creation is always authenticated and the current user lifecycle suspends users rather than deleting them.
+
+### 2. Use the existing flat resource URL style
+
+The REST contract will use:
+
+- `POST /api/v2/test-scenarios` with `{ projectId, title, contentMd }` in the body.
+- `GET /api/v2/test-scenarios?projectId=...&page=...&limit=...`.
+- `GET /api/v2/test-scenarios/{scenarioId}?projectId=...`.
+- `DELETE /api/v2/test-scenarios/{scenarioId}?projectId=...`.
+
+Body/query placement follows comparable existing `/v2/issues`, `/v2/specs`, and `/v2/executions` APIs and matches the issue's prescribed paths. Nested `/projects/{projectId}/test-scenarios` routes were rejected because they would create a new URL convention beyond this issue.
+
+### 3. Validate transport input with shared Zod schemas
+
+Runtime request schemas will validate UUIDs, a non-blank title, non-empty string `contentMd`, and integer pagination. The title will be trimmed before persistence; `contentMd` will not be trimmed or line-ending-normalized. Accepted Markdown is opaque source text: the backend validates its presence and type, not Markdown grammar.
+
+Pagination defaults to page `1` and limit `30`; page and limit must be positive integers and limit is capped at `100`. The same schema definitions or equivalent constraints will drive the OpenAPI contract to prevent runtime/documentation drift.
+
+### 4. Derive creator attribution from authentication
+
+The controller will pass `req.user.id` to the service as `createdById`. The create request body will remain `{ projectId, title, contentMd }`; `createdById` is not client-selectable. If an undeclared creator field is submitted, it cannot override the authenticated identity used for persistence.
+
+Create, list, and detail resource representations will include `createdById`. Nested user profile data is not included in this issue because the requested audit field only requires a stable user reference and returning profile data would expand the response and query contracts. Creator attribution records who created a scenario; it does not grant or restrict read/delete authorization.
+
+### 5. Return a domain-specific stable pagination envelope
+
+List responses will have this shape:
+
+```json
+{
+  "scenarios": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+Records will be ordered by `createdAt DESC` and then `id DESC` so offset pagination is deterministic even when timestamps match. A bare array was rejected because it cannot carry pagination metadata. The unused generic pagination type was not selected because existing resource APIs expose domain-named collections.
+
+### 6. Enforce project scope in every identity-bearing query
+
+Detail lookup and the existence check preceding deletion will filter by both `id` and `projectId`; list and count will share the exact same project predicate. A mismatched or unknown `(scenarioId, projectId)` pair returns `404`, which prevents cross-project mutation and avoids revealing whether the ID exists elsewhere.
+
+Authentication remains mandatory on all four routes. Additional `Project.ownerId` authorization is not introduced because that would be inconsistent with current access semantics and is broader than issue #72.
+
+### 7. Use explicit domain errors and the common error envelope
+
+The scenario service will distinguish validation, not-found, and unexpected failures without controller string matching. Controllers will consistently map them to `400`, `404`, and `500`, while `authMiddleware` retains responsibility for `401`. Error bodies remain `{ "error": "..." }`; successful creation returns `201`, reads return `200`, and deletion returns an empty `204` response.
+
+Creation will verify that the referenced project exists and return `404` when it does not, rather than exposing a Prisma foreign-key error. Unknown projects on a list naturally return an empty page because the operation has no scenario identity to disclose.
+
+### 8. Extend manual project deletion ordering
+
+The existing project model manually deletes related records in a transaction. It will delete `TestScenario` rows before deleting the project. Database-level cascading was rejected for this isolated relation because it would mix deletion strategies inside the same aggregate and make project deletion behavior less explicit.
+
+## Risks / Trade-offs
+
+- **[Risk] Offset pagination can shift when scenarios are inserted between page requests.** → Use deterministic ordering now; cursor pagination can be introduced later without changing stored data.
+- **[Risk] Unbounded Markdown can create large rows or responses.** → Keep this issue faithful to its raw-text requirement and the server's existing request-size controls; introduce a product-defined field limit separately if needed.
+- **[Risk] Authentication without owner authorization permits the same project access currently available in other domain APIs.** → Enforce exact project context here and address owner authorization consistently across project resources in a dedicated security change.
+- **[Risk] Forgetting the manual project-deletion update causes foreign-key failures.** → Include project deletion with scenarios in model/service regression coverage.
+- **[Risk] Accepting `createdById` from request input would allow creator spoofing.** → Exclude it from the request schema and always take the persisted value from `req.user.id`.
+- **[Risk] A required creator foreign key would prevent hard deletion of referenced users.** → The current lifecycle suspends users instead of deleting them; define explicit reassignment or retention semantics before adding hard user deletion.
+- **[Trade-off] Title normalization differs from Markdown preservation.** → Trim only the identifying display title; treat Markdown as opaque source and assert exact round trips in tests.
+
+## Migration Plan
+
+1. Replace the not-yet-finalized initial test-scenario migration with an updated migration that creates the table with both project and required creator foreign keys and their indexes. No data backfill is required because the original migration may be dropped during this implementation phase.
+2. Generate Prisma types before compiling the new model/service code.
+3. Deploy the replacement additive migration before or with the compatible application version; existing production rows and APIs require no backfill.
+4. Roll back application routes before dropping the `TestScenario` table if rollback is necessary. Because no existing domain rows are changed, rollback affects only newly created scenarios.
+
+## Open Questions
+
+None for issue #72. Content-size policy, project-owner authorization, update semantics, and future domain links require separate product decisions and changes.

--- a/openspec/changes/add-markdown-test-scenarios/proposal.md
+++ b/openspec/changes/add-markdown-test-scenarios/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The backend has no first-class model for authored test scenarios, so test-management clients cannot persist Markdown scenario definitions independently from execution-imported specs. This change introduces the first project-scoped test-management slice while deliberately keeping imported execution data and authored scenarios separate.
+
+## What Changes
+
+- Add a project-owned `TestScenario` persistence model containing a title, raw Markdown content, creator attribution, and timestamps.
+- Add authenticated REST operations to create, list, retrieve, and delete test scenarios.
+- Derive each scenario's creator from the authenticated user rather than accepting creator identity from request input.
+- Scope every list, detail, and delete operation to the requested project so scenario identifiers cannot be used across project contexts.
+- Preserve accepted Markdown content exactly across create and read operations without parsing, rendering, or normalization.
+- Add deterministic, validated pagination with a documented response envelope for scenario lists.
+- Delete scenarios independently without modifying imported specs, results, result errors, assumptions, issues, or executions.
+- Keep editing, domain links, MCP tools, client UI, history, attachments, organization, and manual-run support out of scope.
+- Document the new schemas, operations, and error responses in OpenAPI and add migration and regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `markdown-test-scenarios`: Defines project-scoped persistence and authenticated create, paginated list, detail, and delete behavior for raw Markdown test scenarios.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Prisma schema, generated client, replaceable initial migration, user/project relations, and project deletion ordering.
+- New test-scenario route, controller, service, model, validation schemas, shared types, and central route registration.
+- OpenAPI schemas, route registration, API tag metadata, and contract tests.
+- Model, service, controller, route, migration, deletion-isolation, and Markdown round-trip tests.
+- GitHub tracking issue: https://github.com/VENTIONINC/TestPortal-backend/issues/72

--- a/openspec/changes/add-markdown-test-scenarios/specs/markdown-test-scenarios/spec.md
+++ b/openspec/changes/add-markdown-test-scenarios/specs/markdown-test-scenarios/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Test scenarios are independent project-owned records
+The system SHALL persist each test scenario with a UUID identifier, project identifier, required creator user identifier, title, raw Markdown content, creation timestamp, and update timestamp. A test scenario SHALL belong to exactly one existing project, SHALL reference exactly one creating user, and SHALL have no persistence relationship to Specs, Results, ResultErrors, Assumptions, Issues, or Executions.
+
+#### Scenario: Scenario is stored independently
+- **WHEN** a valid scenario is created for an existing project
+- **THEN** the system stores one `TestScenario` record associated with that project
+- **AND** the record's `createdById` references the authenticated user who created it
+- **AND** the system does not create or modify any Spec, Result, ResultError, Assumption, Issue, or Execution record
+
+### Requirement: Authenticated clients can create Markdown scenarios
+The system SHALL expose `POST /api/v2/test-scenarios` to authenticated clients. The request SHALL contain a valid project UUID, a non-blank title, and a non-empty string `contentMd`. The system SHALL derive `createdById` from the authenticated user, SHALL NOT permit request input to select or override the creator, SHALL trim the title, SHALL preserve accepted `contentMd` exactly without parsing or normalization, and SHALL return the created scenario with HTTP 201.
+
+#### Scenario: Create a scenario containing Markdown
+- **WHEN** an authenticated client submits a valid project ID, title, and Markdown source
+- **THEN** the system returns HTTP 201 with the persisted scenario
+- **AND** the response includes its ID, project ID, creator user ID, trimmed title, exact Markdown source, creation timestamp, and update timestamp
+
+#### Scenario: Client cannot spoof the creator
+- **WHEN** an authenticated client submits a create request containing an undeclared creator identifier for a different user
+- **THEN** the system stores the authenticated user's ID as `createdById`
+- **AND** the client-supplied creator value does not affect persistence
+
+#### Scenario: Markdown survives a create and read round trip
+- **WHEN** an authenticated client creates a scenario whose content contains headings, Unicode, code fences, indentation, and line breaks
+- **THEN** the `contentMd` returned by create and subsequent detail retrieval exactly equals the submitted `contentMd`
+
+#### Scenario: Create request is invalid
+- **WHEN** an authenticated client submits a malformed project ID, blank title, missing field, non-string content, or empty `contentMd`
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** no scenario is created
+
+#### Scenario: Project does not exist
+- **WHEN** an authenticated client submits a valid project UUID that identifies no project
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no scenario is created
+
+### Requirement: Authenticated clients can list scenarios by project
+The system SHALL expose `GET /api/v2/test-scenarios` to authenticated clients and SHALL require a valid `projectId` query parameter. Each returned scenario SHALL include its `createdById`. The endpoint SHALL return only scenarios belonging to that project and SHALL never include scenario Markdown or records from another project context by mistake.
+
+#### Scenario: List contains only requested-project scenarios
+- **WHEN** scenarios exist in multiple projects and a client lists one project
+- **THEN** every returned scenario has the requested project ID
+- **AND** no scenario from another project is returned
+
+#### Scenario: Unknown project has no scenarios
+- **WHEN** an authenticated client lists a syntactically valid project UUID with no matching scenarios
+- **THEN** the system returns HTTP 200 with an empty `scenarios` array and zero pagination totals
+
+### Requirement: Scenario lists are validated and deterministically paginated
+The list endpoint SHALL accept positive integer `page` and `limit` parameters, default page to 1, default limit to 30, and reject limits greater than 100. It SHALL order records by creation time descending and then ID descending. It SHALL return exactly `scenarios`, `total`, `page`, `limit`, and `totalPages` as its top-level pagination fields.
+
+#### Scenario: Default pagination is returned
+- **WHEN** an authenticated client lists scenarios with a project ID and omits page and limit
+- **THEN** the system returns the first page with limit 30
+- **AND** `total` and `totalPages` describe all scenarios in the requested project
+
+#### Scenario: Explicit page is returned
+- **WHEN** an authenticated client requests a valid page and limit
+- **THEN** the system returns the matching deterministic slice
+- **AND** echoes the resolved page and limit in the response
+
+#### Scenario: Pagination is invalid
+- **WHEN** page or limit is non-numeric, fractional, zero, negative, or limit exceeds 100
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Authenticated clients can retrieve a scenario within a project context
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}` to authenticated clients and SHALL require valid `scenarioId` and `projectId` UUIDs. The lookup SHALL match both identifiers.
+
+#### Scenario: Retrieve a matching scenario
+- **WHEN** an authenticated client requests an existing scenario with its owning project ID
+- **THEN** the system returns HTTP 200 with the complete scenario, including exact Markdown source
+- **AND** the response identifies the scenario's creator through `createdById`
+
+#### Scenario: Scenario is absent from the requested project context
+- **WHEN** the scenario does not exist or belongs to a different project than the requested project ID
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+
+#### Scenario: Detail identifiers are invalid
+- **WHEN** an authenticated client supplies a missing or malformed project ID or malformed scenario ID
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Authenticated clients can delete only the requested-project scenario
+The system SHALL expose `DELETE /api/v2/test-scenarios/{scenarioId}` to authenticated clients and SHALL require valid `scenarioId` and `projectId` UUIDs. Deletion SHALL remove only the scenario matching both identifiers and SHALL return an empty HTTP 204 response.
+
+#### Scenario: Delete a matching scenario
+- **WHEN** an authenticated client deletes an existing scenario with its owning project ID
+- **THEN** the system returns HTTP 204 with no response body
+- **AND** subsequent retrieval of that scenario in the same project returns HTTP 404
+
+#### Scenario: Cross-project delete is rejected
+- **WHEN** an authenticated client supplies an existing scenario ID with a different project ID
+- **THEN** the system returns HTTP 404
+- **AND** the scenario remains stored in its owning project
+
+#### Scenario: Scenario deletion leaves other domains unchanged
+- **WHEN** a scenario is deleted from a project that also has Specs, Results, ResultErrors, Assumptions, Issues, and Executions
+- **THEN** none of those records are modified or deleted
+
+### Requirement: Project deletion remains valid with scenarios
+The system SHALL remove a project's test scenarios as part of the existing transactional project deletion flow before deleting the project itself.
+
+#### Scenario: Delete a project containing scenarios
+- **WHEN** the existing project deletion operation deletes a project that has test scenarios
+- **THEN** all scenarios belonging to that project are removed
+- **AND** project deletion completes without a foreign-key failure
+
+### Requirement: Scenario APIs require authentication and have documented contracts
+All test-scenario routes SHALL use the existing JWT authentication middleware. OpenAPI SHALL document `createdById` as a required scenario response field but not as create-request input. OpenAPI SHALL also document request parameters and bodies, success schemas, the stable pagination envelope, bearer authentication, and applicable 400, 401, 404, and 500 error responses using the common error schema.
+
+#### Scenario: Request is unauthenticated
+- **WHEN** a client calls any test-scenario route without a valid authentication token
+- **THEN** the system returns HTTP 401 with an `{ "error": string }` response
+- **AND** no scenario data is returned or mutated
+
+#### Scenario: OpenAPI document is generated
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** all four test-scenario operations and their request and response schemas are present under a Test Scenarios tag

--- a/openspec/changes/add-markdown-test-scenarios/tasks.md
+++ b/openspec/changes/add-markdown-test-scenarios/tasks.md
@@ -1,0 +1,54 @@
+## 1. Persistence Model and Migration
+
+- [x] 1.1 Add the project relation and independent `TestScenario` Prisma model with UUID identifiers, raw text content, timestamps, and project-oriented indexes.
+- [x] 1.2 Create and review the forward Prisma migration for the test-scenario table, foreign key, and indexes, then regenerate the Prisma client.
+- [x] 1.3 Extend the transactional project-deletion model flow to remove project scenarios before deleting the project.
+- [x] 1.4 Add migration/schema regression coverage proving the new table contract and independence from execution and issue tables.
+
+## 2. Request Contracts and Domain Types
+
+- [x] 2.1 Create header-compliant test-scenario schema/type files using the repository new-file workflow.
+- [x] 2.2 Define shared Zod validation for create input, scenario/project identifiers, and page/limit query parameters with defaults and the limit cap.
+- [x] 2.3 Define typed scenario responses, domain errors, and the stable `{ scenarios, total, page, limit, totalPages }` list envelope without using `any`.
+
+## 3. Model and Service Layers
+
+- [x] 3.1 Implement the test-scenario model create, project-filtered list/count, composite detail lookup, and composite delete support with deterministic ordering.
+- [x] 3.2 Add model tests for create data, project isolation, list/count predicate alignment, ordering, pagination offsets, composite lookup, and composite deletion.
+- [x] 3.3 Implement the test-scenario service for project existence checks, title normalization, exact Markdown preservation, paginated reads, not-found behavior, and isolated deletion.
+- [x] 3.4 Add service tests for Markdown round trips, pagination metadata, unknown projects, cross-project access, domain-error classification, and deletion isolation.
+
+## 4. Controller and Route Integration
+
+- [x] 4.1 Implement controller handlers for create, list, detail, and delete with shared Zod validation and consistent 201/200/204/400/404/500 responses.
+- [x] 4.2 Register all four `/api/v2/test-scenarios` routes behind `authMiddleware` and mount the router in the central API router.
+- [x] 4.3 Add controller tests for accepted and rejected inputs, status/error mappings, stable list responses, exact Markdown responses, and empty 204 deletion.
+- [x] 4.4 Add route tests proving JWT protection, route wiring, query/body handoff, and the absence of update or MCP operations.
+
+## 5. OpenAPI Contract
+
+- [x] 5.1 Add OpenAPI component schemas for scenario resources, create input, identifiers, pagination queries, and the stable list response.
+- [x] 5.2 Register the four test-scenario operations, bearer security, success responses, and common 400/401/404/500 error responses.
+- [x] 5.3 Register the Test Scenarios tag and route registrar in the generated OpenAPI document.
+- [x] 5.4 Add OpenAPI contract tests asserting operation presence, request/response schemas, pagination constraints, authentication, and documented errors.
+
+## 6. Cross-Domain Regression Coverage
+
+- [x] 6.1 Add regression coverage proving scenario deletion changes only the selected `TestScenario` record and leaves Specs, Results, ResultErrors, Assumptions, Issues, and Executions unchanged.
+- [x] 6.2 Add project-deletion regression coverage proving scenarios are removed transactionally without foreign-key failures.
+- [x] 6.3 Add end-to-end create/list/detail/delete coverage across two project contexts, including cross-project 404 behavior and deterministic pagination.
+
+## 7. Verification
+
+- [x] 7.1 Run `npm run type-check` and resolve all strict TypeScript errors.
+- [x] 7.2 Run `npm run lint` and resolve all ESLint or license-header violations.
+- [x] 7.3 Run `npm test` and confirm the complete Jest suite passes.
+- [x] 7.4 Run `npm run build` and confirm the production build succeeds.
+
+## 8. Creator Attribution Amendment
+
+- [x] 8.1 Replace the disposable initial test-scenario migration and update the Prisma schema with required `createdById`, the named User/TestScenario relation, and a creator index, then regenerate the Prisma client.
+- [x] 8.2 Thread the authenticated user's ID from the controller through service and model creation without adding `createdById` to the public create-request schema.
+- [x] 8.3 Add `createdById` to scenario response types and OpenAPI response schemas while keeping it absent from create input.
+- [x] 8.4 Update migration, model, service, controller, route, workflow, and OpenAPI tests for required creator persistence, response exposure, and creator-spoofing prevention.
+- [x] 8.5 Re-run `npm run type-check`, `npm run lint`, `npm test`, and `npm run build` after the creator-attribution changes.

--- a/openspec/changes/edit-markdown-test-scenarios/.openspec.yaml
+++ b/openspec/changes/edit-markdown-test-scenarios/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/edit-markdown-test-scenarios/design.md
+++ b/openspec/changes/edit-markdown-test-scenarios/design.md
@@ -1,0 +1,91 @@
+## Context
+
+The backend now supports authenticated creation, listing, detail, deletion, and execution-evidence integration for project-scoped Markdown Test Scenarios. The persisted model already contains editable `title` and `contentMd` fields plus Prisma-managed `updatedAt`; therefore issue #74 is an API and MVC-layer change, not a persistence migration.
+
+Scenario identity, creator attribution, project ownership, and Spec links have separate lifecycles from authored content. Updating content must preserve those fields and relations. The current API treats accepted Markdown as opaque source text and trims scenario titles, so update semantics must match create semantics without silently replacing omitted values.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide authenticated project-scoped partial updates through PATCH.
+- Update title, Markdown content, or both atomically.
+- Preserve omitted and read-only fields and every Spec/evidence relation.
+- Preserve accepted Markdown exactly and return the persisted detail representation.
+- Reject ambiguous empty updates and attempts to mutate unsupported fields.
+- Keep validation, error, and MVC behavior consistent with existing scenario endpoints.
+
+**Non-Goals:**
+
+- Full-replacement PUT semantics.
+- Optimistic locking, ETags, version numbers, or merge conflict detection.
+- Revision history, edit attribution, or audit-event persistence.
+- Editing `projectId`, `createdById`, timestamps, or Spec links.
+- Client UI or MCP mutation support.
+
+## Decisions
+
+### 1. Use PATCH with explicit partial-update semantics
+
+Add `PATCH /api/v2/test-scenarios/{scenarioId}?projectId=...`. The JSON body may contain `title`, `contentMd`, or both. Omitted fields retain their stored values. Supplying both fields updates them in one database operation.
+
+PATCH directly matches the requirement to edit one field without replacing the other. PUT was rejected because complete replacement would require both fields on every request and creates accidental data-loss risk for clients editing a single field.
+
+Successful updates return HTTP 200 with the same complete Test Scenario representation as the detail endpoint. There is no separate update response type.
+
+### 2. Express at-least-one-field validation structurally
+
+Define a strict Zod update schema as a union of:
+
+- `{ title: validTitle, contentMd?: validContent }`
+- `{ title?: validTitle, contentMd: validContent }`
+
+This makes at least one field structurally required in runtime validation and the generated OpenAPI contract. Both alternatives reject unknown keys. An empty object, null values, non-string values, and read-only fields such as `projectId`, `createdById`, `createdAt`, and `updatedAt` return HTTP 400 rather than being ignored.
+
+Using a fully optional object with only a runtime refinement was rejected because OpenAPI generation may not communicate the non-empty-object constraint reliably. Silently stripping unknown fields was rejected because it can make a client believe an unsupported mutation succeeded.
+
+### 3. Normalize titles but preserve Markdown source
+
+Updated titles use the same rule as creation: trim surrounding whitespace and reject a result with zero characters. Updated `contentMd` must be a string with at least one character but is not trimmed, parsed, sanitized, or line-ending-normalized. Whitespace-only Markdown remains accepted because the existing creation contract validates raw length rather than semantic content.
+
+The service repeats the essential domain checks even though the controller validates transport input, preserving a reusable service boundary for future callers.
+
+### 4. Keep project scope inside the persistence operation
+
+The controller validates the scenario path UUID and required project query UUID. The model update verifies `(scenarioId, projectId)` and performs the update within one transaction, returning the persisted row or `null` when the scenario is absent from that context. The service maps `null` to the existing scenario not-found error and the controller returns HTTP 404.
+
+The update data type contains only `title` and `contentMd`, preventing controllers or future callers from passing project, creator, timestamp, or relation mutations through this method. A model method that updates directly by ID without checking project context was rejected because it weakens the tenant boundary.
+
+### 5. Preserve metadata and integration links
+
+An update changes only supplied authored fields and Prisma-managed `updatedAt`. It preserves `id`, `projectId`, `createdById`, `createdAt`, all `TestScenarioSpecLink` rows, linked Specs, and all derived Results and Issues. No `updatedById` is added because edit attribution and audit history are explicitly out of scope.
+
+Evidence endpoints continue to resolve links by stable scenario ID, so content edits require no integration refresh or reconciliation.
+
+### 6. Use last-write-wins concurrency behavior
+
+No version or timestamp precondition is required. Concurrent valid updates are committed in database order and the last committed value for each supplied field is authoritative. Each response represents the row persisted by that operation, and `updatedAt` is managed by Prisma.
+
+This is intentionally simple for the first editing slice. Optimistic locking was rejected because it requires a new client contract, conflict response, and possibly schema changes beyond issue #74.
+
+### 7. Reuse existing error and route conventions
+
+Invalid input returns 400, authentication failures remain owned by `authMiddleware` and return 401, project-context misses return 404, and unexpected failures return 500. All errors use `{ "error": string }`. Register PATCH on the existing scenario resource route alongside GET and DELETE; nested Spec-link and evidence routes remain unchanged.
+
+## Risks / Trade-offs
+
+- **[Risk] Concurrent editors can overwrite one another.** → Document last-write-wins behavior and defer optimistic locking to a dedicated change.
+- **[Risk] Unknown fields could be silently discarded by default Zod behavior.** → Use a strict update schema and test every read-only field.
+- **[Risk] Markdown normalization could corrupt meaningful formatting.** → Store the exact accepted string and assert Unicode, code-fence, whitespace, and line-ending round trips.
+- **[Risk] An ID-only model update could cross project context.** → Scope the model lookup/update transaction by both scenario ID and requested project ID.
+- **[Trade-off] Updating an unchanged value still advances `updatedAt`.** → Treat every valid PATCH as an intentional write; no semantic no-op detection is added.
+
+## Migration Plan
+
+1. Add the update schemas, types, model/service/controller methods, route, and OpenAPI operation without changing Prisma schema or migration history.
+2. Deploy as a backward-compatible additive API operation; existing clients and stored scenarios require no migration or backfill.
+3. Rollback removes the PATCH route and supporting code only. Existing rows remain valid because no storage contract changes.
+
+## Open Questions
+
+None for issue #74. Optimistic locking, revision history, edit attribution, and update support through MCP remain separate product decisions.

--- a/openspec/changes/edit-markdown-test-scenarios/proposal.md
+++ b/openspec/changes/edit-markdown-test-scenarios/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Markdown Test Scenarios can be created and read but cannot be corrected or evolved after creation. Adding a project-scoped partial update completes the basic authored-scenario lifecycle without introducing revision or concurrency systems.
+
+## What Changes
+
+- Add authenticated `PATCH /api/v2/test-scenarios/{scenarioId}` behavior for project-scoped partial updates.
+- Allow clients to update `title`, `contentMd`, or both atomically while preserving omitted fields.
+- Require at least one editable field and reject empty, null, malformed, unknown, or read-only fields.
+- Trim and validate updated titles while preserving accepted Markdown content exactly as submitted.
+- Return the persisted scenario through the existing detail response contract with an advanced `updatedAt` timestamp.
+- Preserve `id`, `projectId`, `createdById`, `createdAt`, Spec links, Results, and Issues during updates.
+- Use last-write-wins semantics and keep optimistic locking, revisions, edit attribution, audit history, client UI, link editing, and MCP mutations out of scope.
+- Document PATCH semantics and error responses in OpenAPI and add model, service, controller, route, round-trip, and integration regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `markdown-test-scenario-editing`: Defines authenticated project-scoped partial updates for scenario titles and raw Markdown content, including validation and preservation rules.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Test-scenario request schemas, shared types, model, service, controller, and router.
+- Test-scenario OpenAPI components, PATCH operation registration, and contract tests.
+- Model, service, controller, route, Markdown round-trip, project-isolation, and Spec-link regression tests.
+- No Prisma schema or database migration is required; the existing `updatedAt` field records the write timestamp.
+- Depends on the completed `add-markdown-test-scenarios` change and remains compatible with `integrate-test-scenarios-with-execution-evidence`.
+- GitHub tracking issue: https://github.com/VENTIONINC/TestPortal-backend/issues/74

--- a/openspec/changes/edit-markdown-test-scenarios/specs/markdown-test-scenario-editing/spec.md
+++ b/openspec/changes/edit-markdown-test-scenarios/specs/markdown-test-scenario-editing/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Authenticated clients can partially update a Test Scenario
+The system SHALL expose `PATCH /api/v2/test-scenarios/{scenarioId}` to authenticated clients and SHALL require a valid `projectId` query parameter. The request SHALL contain `title`, `contentMd`, or both, and the system SHALL update all supplied editable fields atomically while preserving omitted fields.
+
+#### Scenario: Update only the title
+- **WHEN** an authenticated client submits a valid title without `contentMd` for a scenario in the requested project
+- **THEN** the system updates the trimmed title
+- **AND** preserves the stored Markdown content exactly
+
+#### Scenario: Update only the Markdown content
+- **WHEN** an authenticated client submits valid `contentMd` without a title for a scenario in the requested project
+- **THEN** the system updates the Markdown content exactly as submitted
+- **AND** preserves the stored title
+
+#### Scenario: Update title and Markdown together
+- **WHEN** an authenticated client submits valid title and `contentMd` fields
+- **THEN** the system persists both supplied values in one update operation
+- **AND** returns the resulting scenario
+
+### Requirement: Update input is strict and non-empty
+The update body SHALL contain at least one editable field. Supplied titles SHALL be strings that remain non-empty after trimming, and supplied `contentMd` values SHALL be non-empty strings. The system SHALL reject null, malformed, unknown, and read-only fields rather than silently ignoring them.
+
+#### Scenario: Empty update is rejected
+- **WHEN** an authenticated client submits an empty JSON object
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** leaves the scenario unchanged
+
+#### Scenario: Blank title is rejected
+- **WHEN** an authenticated client submits a title that is empty or contains only whitespace
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** leaves the scenario unchanged
+
+#### Scenario: Empty Markdown is rejected
+- **WHEN** an authenticated client submits `contentMd` as an empty string
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** leaves the scenario unchanged
+
+#### Scenario: Null or non-string value is rejected
+- **WHEN** an authenticated client submits null or a non-string value for an editable field
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** leaves the scenario unchanged
+
+#### Scenario: Unknown or read-only field is rejected
+- **WHEN** an authenticated client submits an unknown field or attempts to submit `projectId`, `createdById`, `createdAt`, or `updatedAt` in the body
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** does not apply any supplied mutation
+
+### Requirement: Updated Markdown is preserved exactly
+The system SHALL persist accepted update `contentMd` as opaque source text without trimming, parsing, sanitizing, or line-ending normalization. The update response and subsequent detail reads SHALL return the exact submitted Markdown string.
+
+#### Scenario: Complex Markdown survives update and read
+- **WHEN** an authenticated client updates `contentMd` containing Unicode, headings, code fences, indentation, trailing whitespace, and line breaks
+- **THEN** the update response returns exactly the submitted string
+- **AND** a subsequent detail request returns the same string
+
+#### Scenario: Whitespace-only Markdown follows existing raw-content rules
+- **WHEN** an authenticated client submits a non-empty `contentMd` containing only whitespace
+- **THEN** the system accepts and preserves it exactly
+
+### Requirement: Updates are scoped to the requested project
+The system SHALL match both `scenarioId` and `projectId` before applying an update. A scenario that is absent from the requested project context SHALL not be disclosed or modified.
+
+#### Scenario: Update matching project scenario
+- **WHEN** an authenticated client updates an existing scenario using its owning project ID
+- **THEN** the system applies the valid update and returns HTTP 200
+
+#### Scenario: Cross-project update is rejected
+- **WHEN** an authenticated client supplies an existing scenario ID with a different project ID
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** the scenario remains unchanged in its owning project
+
+#### Scenario: Update identifiers are invalid
+- **WHEN** the scenario ID or project ID is missing or malformed
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** no scenario is modified
+
+### Requirement: Updates preserve scenario identity, attribution, and evidence links
+An update SHALL modify only supplied authored fields and the Prisma-managed `updatedAt` timestamp. The system SHALL preserve `id`, `projectId`, `createdById`, `createdAt`, all scenario/Spec links, linked Specs, Results, ResultErrors, Assumptions, and Issues.
+
+#### Scenario: Metadata remains immutable
+- **WHEN** a valid scenario update succeeds
+- **THEN** the response retains the original ID, project ID, creator user ID, and creation timestamp
+- **AND** contains an updated write timestamp
+
+#### Scenario: Spec links and evidence remain unchanged
+- **WHEN** a linked scenario's title or Markdown content is updated
+- **THEN** every existing scenario/Spec link remains stored
+- **AND** linked Result and Issue evidence queries continue to return the same domain records
+
+### Requirement: Successful updates return the detail contract
+The system SHALL return HTTP 200 with the persisted scenario using the same response schema as the scenario detail endpoint. Each valid PATCH SHALL use last-write-wins semantics and SHALL advance `updatedAt`, including when the supplied value equals the existing value.
+
+#### Scenario: Updated scenario is returned
+- **WHEN** a valid update succeeds
+- **THEN** the response contains the complete persisted scenario with updated authored fields
+- **AND** its `updatedAt` is later than the previous stored timestamp
+
+#### Scenario: Later update wins
+- **WHEN** multiple valid updates target the same field without an optimistic-lock precondition
+- **THEN** the value from the last committed update is persisted
+- **AND** no concurrency conflict response is required
+
+### Requirement: Editing is authenticated and documented
+The PATCH route SHALL use the existing JWT authentication middleware. OpenAPI SHALL document partial-update semantics, strict request alternatives, the shared scenario response, bearer authentication, and applicable 400, 401, 404, and 500 error responses using the common error schema. The API SHALL NOT expose PUT editing for this iteration.
+
+#### Scenario: Update request is unauthenticated
+- **WHEN** a client calls the PATCH route without a valid authentication token
+- **THEN** the system returns HTTP 401 with an `{ "error": string }` response
+- **AND** the scenario remains unchanged
+
+#### Scenario: OpenAPI document is generated
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** the PATCH operation and strict partial-update request schema are documented under the Test Scenarios tag
+- **AND** no PUT operation is documented for the scenario resource

--- a/openspec/changes/edit-markdown-test-scenarios/tasks.md
+++ b/openspec/changes/edit-markdown-test-scenarios/tasks.md
@@ -1,0 +1,40 @@
+## 1. Update Contracts and Validation
+
+- [x] 1.1 Add strict Zod PATCH request alternatives that require title, `contentMd`, or both and reject unknown, null, and read-only fields.
+- [x] 1.2 Add typed update input/data interfaces containing only optional `title` and `contentMd` fields with an at-least-one-field service contract.
+- [x] 1.3 Add schema tests for title-only, Markdown-only, combined, empty, malformed, null, unknown, and read-only-field bodies.
+
+## 2. Model and Service Update Behavior
+
+- [x] 2.1 Implement a Test Scenario model update that scopes lookup and mutation by scenario ID and project ID in one transaction and returns the persisted row or `null`.
+- [x] 2.2 Add model tests for project-scoped success, cross-project misses, atomic combined updates, omitted-field preservation, and immutable metadata/relations.
+- [x] 2.3 Implement service partial-update behavior with defensive at-least-one-field validation, title trimming, exact Markdown preservation, and existing not-found errors.
+- [x] 2.4 Add service tests for title-only, Markdown-only, combined, no-op-value, last-write-wins, invalid input, and cross-project behavior.
+
+## 3. Controller and Route Integration
+
+- [x] 3.1 Implement the PATCH controller handler using existing scenario path/project schemas, strict body validation, shared error mapping, and the detail response contract.
+- [x] 3.2 Register authenticated PATCH on `/api/v2/test-scenarios/:scenarioId` without changing nested Spec-link or evidence route behavior.
+- [x] 3.3 Add controller tests for 200/400/404/500 mappings, full persisted responses, and unchanged state after rejected updates.
+- [x] 3.4 Add route tests for JWT protection, query/path/body handoff, PATCH availability, PUT absence, and cross-project rejection.
+
+## 4. OpenAPI Contract
+
+- [x] 4.1 Add a strict partial-update OpenAPI request schema that structurally requires at least one editable field and excludes read-only fields.
+- [x] 4.2 Register PATCH with bearer security, the shared Test Scenario success schema, and documented 400/401/404/500 error responses.
+- [x] 4.3 Add OpenAPI contract tests for partial alternatives, strict field exposure, shared response reuse, Test Scenarios tagging, and PUT absence.
+
+## 5. Round-Trip and Integration Regression Coverage
+
+- [x] 5.1 Add update/read round-trip coverage for Unicode, headings, code fences, indentation, trailing whitespace, whitespace-only content, and line endings.
+- [x] 5.2 Add regression coverage proving `id`, `projectId`, `createdById`, and `createdAt` remain unchanged while `updatedAt` advances.
+- [x] 5.3 Add regression coverage proving all scenario/Spec links and derived Result/Issue evidence remain unchanged after title or Markdown updates.
+- [x] 5.4 Run focused MVC-boundary, OpenAPI-contract, and Jest-pattern reviews and resolve identified drift.
+
+## 6. Verification
+
+- [x] 6.1 Confirm no Prisma schema change or migration is introduced for scenario editing.
+- [x] 6.2 Run `npm run type-check` and resolve all strict TypeScript errors.
+- [x] 6.3 Run `npm run lint` and resolve all ESLint or license-header violations.
+- [x] 6.4 Run `npm test` and confirm the complete Jest suite passes.
+- [x] 6.5 Run `npm run build` and confirm the production build succeeds.

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/.openspec.yaml
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/design.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/design.md
@@ -1,0 +1,141 @@
+## Context
+
+The completed Markdown Test Scenario slice provides authenticated project-scoped CRUD for authored scenarios. Automated execution evidence remains owned by the existing graph `Spec → Result → ResultError → Assumption → Issue`. Issue #73 must connect those domains without copying ownership, mutating imported data, or creating direct scenario links to individual Results or Issues.
+
+Coverage is many-to-many: one authored scenario can be exercised by several Specs, and one Spec can support several scenarios. Links are strictly local to one project. Existing Result filters distinguish a Spec business key from a database Spec record ID, and existing Issue list queries do not yet express the complete scenario evidence traversal, so reusable service-level query entry points are needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist unique, project-local many-to-many scenario/Spec links.
+- Provide authenticated add, paginated list, and remove operations for links.
+- Aggregate deterministic, paginated Result history across all linked Specs.
+- Derive deterministic, paginated, deduplicated observed Issues from existing Assumptions.
+- Distinguish unlinked scenarios from linked scenarios that have no evidence.
+- Preserve both endpoint records and all evidence when a link is removed.
+- Keep orchestration reusable by REST and future MCP handlers.
+
+**Non-Goals:**
+
+- Cross-project links or reads.
+- Direct scenario links to Results or Issues.
+- Automatic matching by title, file, key, or report ingestion.
+- Link notes, weights, coverage types, scoring, or audit metadata.
+- Rendering scenario integration in a client or exposing MCP tools.
+- Changing confirmation semantics or ownership of Assumptions and Issues.
+
+## Decisions
+
+### 1. Use an explicit join model
+
+Add `TestScenarioSpecLink` with `testScenarioId` and `specId` as a composite primary key. Add relation collections to `TestScenario` and `Spec`, and an index beginning with `specId` for reverse lookup. Both foreign keys use `onDelete: Cascade` because the join row has no independent lifecycle: deleting either endpoint removes only its links.
+
+An explicit join model is preferred over a nullable foreign key because the relationship is many-to-many. It is preferred over Prisma's implicit many-to-many relation because a named model makes constraints, migrations, model ownership, and future extension explicit. No link metadata is added in this issue.
+
+The link table does not store `projectId`. The service proves project locality by loading both endpoints with the same requested `projectId` before insertion. Project IDs are immutable in current behavior, so this does not create a later drift path. Adding redundant project columns and composite foreign keys was rejected as disproportionate complexity.
+
+### 2. Expose resource-oriented link operations
+
+Add these authenticated routes:
+
+- `POST /api/v2/test-scenarios/{scenarioId}/spec-links?projectId=...` with `{ "specId": "uuid" }`.
+- `GET /api/v2/test-scenarios/{scenarioId}/spec-links?projectId=...&page=1&limit=30`.
+- `DELETE /api/v2/test-scenarios/{scenarioId}/spec-links/{specId}?projectId=...`.
+
+Creation returns HTTP 201 with `{ scenarioId, specId }`. The composite primary key is the final race-safe duplicate guard; a Prisma unique violation maps to HTTP 409. Removing an existing link returns an empty HTTP 204 response. An absent link or a scenario/Spec outside the requested project context returns HTTP 404, consistent with existing scenario identity protection.
+
+A single PATCH that replaces a `specId` was rejected because it encodes one-to-one cardinality and makes multi-link additions/removals less explicit.
+
+### 3. Return paginated linked Specs
+
+The linked-Spec response is:
+
+```json
+{
+  "scenarioId": "uuid",
+  "projectId": "uuid",
+  "specs": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+It reuses the normalized public Spec representation and orders Specs by `createdAt DESC, id DESC`. Page defaults to 1, limit defaults to 30, and limit is capped at 100, matching the scenario API.
+
+### 4. Aggregate Results by Spec record IDs
+
+Add `GET /api/v2/test-scenarios/{scenarioId}/results?projectId=...&page=1&limit=30` with this envelope:
+
+```json
+{
+  "scenarioId": "uuid",
+  "projectId": "uuid",
+  "linkedSpecCount": 0,
+  "results": [],
+  "total": 0,
+  "page": 1,
+  "limit": 30,
+  "totalPages": 0
+}
+```
+
+The query unions Results whose database `specId` belongs to any linked Spec, returns each Result once, applies the existing normalized public Result representation, and orders by `startTime DESC, id DESC`. It also retains the existing defense-in-depth requirement that both the Result's Spec and Execution belong to the requested project.
+
+Expose a reusable Result service method explicitly named for Spec record IDs rather than overloading the existing public `specId` filter, which currently means the Spec business key. Returning `linkedSpecCount` lets consumers distinguish an unlinked scenario from linked Specs with no Results without embedding an unbounded Spec-ID list.
+
+### 5. Query observed Issues directly and deduplicate by identity
+
+Add `GET /api/v2/test-scenarios/{scenarioId}/issues?projectId=...&page=1&limit=30` using the same envelope, with `issues` replacing `results`. The Issue predicate traverses:
+
+```text
+Issue.assumptions
+  → ResultError
+  → Result
+  → linked Spec IDs
+```
+
+Every Issue reached through an Assumption is observed regardless of `isConfirmed`. Querying Issue records directly naturally returns one row per Issue even if several errors, assumptions, Results, or linked Specs reach it. Results are ordered by `createdAt DESC, id DESC` and use the existing normalized public Issue representation.
+
+A flattened join followed by application-level deduplication was rejected because it inflates intermediate rows and makes count/pagination incorrect. A direct Scenario-to-Issue relation was rejected because it would duplicate evidence ownership and lose provenance.
+
+### 6. Centralize integration orchestration in services
+
+Add a `testScenarioIntegrationService` that validates scenario context, resolves linked Spec IDs/counts, and coordinates reusable Result and Issue service methods. A dedicated link model owns join persistence and paginated Spec reads. Controllers validate transport input and map typed validation, not-found, and conflict errors; they do not build Prisma predicates.
+
+This keeps REST thin and gives future MCP handlers a service API. Calling Result/Issue models directly from controllers or duplicating evidence traversal in handlers was rejected.
+
+### 7. Use consistent pagination and error contracts
+
+All three list/read endpoints accept positive integer `page` and `limit`, with defaults 1 and 30 and maximum limit 100. Counts and item queries use identical link, project, and evidence predicates. Invalid input returns 400, missing authentication returns 401, project-context misses return 404, duplicate links return 409, and unexpected failures return 500, all using `{ "error": string }`.
+
+An unlinked scenario is still a valid resource and returns HTTP 200 with `linkedSpecCount: 0`, an empty collection, and zero totals. An unknown scenario returns 404.
+
+### 8. Add indexes for the evidence traversal
+
+In addition to the composite link primary key and reverse Spec index, add or confirm supporting indexes for Result lookup by Spec/time and the ResultError/Assumption foreign-key traversal used by observed-Issue queries. Index definitions must follow actual Prisma query predicates and be reviewed against existing indexes to avoid duplication.
+
+This adds some migration/write overhead but prevents evidence reads from degenerating into repeated full scans as execution history grows.
+
+## Risks / Trade-offs
+
+- **[Risk] Evidence queries can traverse large histories.** → Require bounded pagination, count with the same predicate, and add supporting foreign-key/query indexes.
+- **[Risk] Duplicate link checks race under concurrent requests.** → Enforce the composite primary key in PostgreSQL and map the unique violation to 409.
+- **[Risk] Cross-project links could be created by trusting IDs independently.** → Resolve both scenario and Spec through the same `projectId` before inserting and cover cross-project attempts in model/service/route tests.
+- **[Risk] The same Issue may appear through many evidence paths.** → Query distinct Issue entities directly so count and pagination operate on Issue identity.
+- **[Risk] A Spec key may change and ingestion may create a new Spec record.** → Keep automatic reconciliation out of scope; links intentionally target stable database Spec records.
+- **[Trade-off] Offset pagination can shift as new Results arrive.** → Use deterministic secondary ordering now; cursor pagination can be introduced later without changing relation storage.
+- **[Trade-off] Cascade deletion removes links when a Spec is deleted.** → Preserve scenarios while retaining the repository's existing Spec-deletion semantics for execution data.
+
+## Migration Plan
+
+1. Add the join model, endpoint relations, composite primary key, reverse index, and reviewed evidence-query indexes in an additive Prisma migration.
+2. Generate Prisma client types and deploy the migration before or with application code that accesses the new table.
+3. No backfill is required; existing scenarios begin with zero links and therefore return empty evidence collections.
+4. Rollback application routes before dropping the join table and newly introduced nonessential indexes. Dropping the link table removes associations only and does not modify scenarios or execution history.
+
+## Open Questions
+
+None for issue #73. Automatic Spec reconciliation, selected-Result evidence, confirmation-only Issue views, link metadata, and coverage scoring remain separate product decisions.

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/proposal.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Managed Test Scenarios are currently isolated from automated execution evidence, so consumers cannot determine which Results or Issues demonstrate a scenario's behavior. This change connects authored scenarios to project-local automated Specs while retaining the existing Spec-owned execution graph as the source of truth.
+
+## What Changes
+
+- Add an explicit project-local many-to-many association between `TestScenario` and `Spec`.
+- Allow authenticated clients to add, list, and remove scenario/Spec links through REST operations.
+- Enforce uniqueness for each scenario/Spec pair and reject cross-project links.
+- Expose independently paginated Results aggregated across every Spec linked to a scenario.
+- Expose independently paginated, deduplicated Issues derived through linked Specs, Results, ResultErrors, and Assumptions.
+- Treat Issues reached through any existing Assumption as observed, regardless of confirmation state.
+- Return stable empty integration responses when a scenario has no linked Specs or no execution evidence.
+- Preserve Test Scenarios, Specs, Results, ResultErrors, Assumptions, and Issues when individual links are removed.
+- Remove only scenario link rows when a Test Scenario is deleted, preserving the existing execution and issue graph.
+- Keep direct Scenario-to-Result and Scenario-to-Issue links, automatic matching, coverage scoring, link metadata, UI, and MCP tools out of scope.
+- Document link-management and evidence-query contracts in OpenAPI and add migration and regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-scenario-execution-evidence`: Defines project-local many-to-many scenario/Spec links, authenticated link management, aggregated Result history, and derived observed-Issue queries.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Prisma schema, generated client, migration history, and scenario/Spec relation deletion behavior.
+- Test-scenario schemas, types, models, services, controllers, and routes.
+- Result and Issue model/service query paths reused or extended for Spec-record aggregation and evidence derivation.
+- OpenAPI component schemas, route registration, and contract tests.
+- Link-model, integration-service, controller, route, aggregation, deduplication, project-isolation, and deletion-safety tests.
+- Depends on the completed `add-markdown-test-scenarios` change and GitHub issue #72.
+- GitHub tracking issue: https://github.com/VENTIONINC/TestPortal-backend/issues/73

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/specs/test-scenario-execution-evidence/spec.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/specs/test-scenario-execution-evidence/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: Test Scenarios and Specs have project-local many-to-many links
+The system SHALL represent Test Scenario coverage through an explicit many-to-many link between `TestScenario` and `Spec`. A scenario MAY link to multiple Specs, a Spec MAY link to multiple scenarios, and each `(testScenarioId, specId)` pair SHALL be unique. Both endpoints of every link SHALL belong to the requested project.
+
+#### Scenario: Scenario links to several Specs
+- **WHEN** an authenticated client links one scenario to multiple Specs in the same project
+- **THEN** the system stores one unique link for each scenario/Spec pair
+- **AND** all linked Specs remain independently owned execution records
+
+#### Scenario: Spec links to several scenarios
+- **WHEN** an authenticated client links one Spec to multiple scenarios in the same project
+- **THEN** the system stores each unique scenario/Spec pair
+- **AND** no existing scenario link for that Spec is replaced
+
+#### Scenario: Cross-project link is rejected
+- **WHEN** the scenario and target Spec do not both belong to the requested project
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no link is created
+
+### Requirement: Authenticated clients can add Spec links
+The system SHALL expose `POST /api/v2/test-scenarios/{scenarioId}/spec-links` to authenticated clients. The endpoint SHALL require a valid `projectId` query parameter and valid `specId` body field, and SHALL return HTTP 201 with the stored scenario and Spec identifiers.
+
+#### Scenario: Add a new Spec link
+- **WHEN** an authenticated client submits a same-project scenario ID and Spec ID that are not already linked
+- **THEN** the system returns HTTP 201 with `{ "scenarioId": string, "specId": string }`
+- **AND** the association becomes available to linked-Spec and evidence queries
+
+#### Scenario: Duplicate link is rejected
+- **WHEN** an authenticated client submits a scenario/Spec pair that already exists
+- **THEN** the system returns HTTP 409 with an `{ "error": string }` response
+- **AND** exactly one copy of the link remains stored
+
+#### Scenario: Add-link input is invalid
+- **WHEN** the scenario ID, project ID, or Spec ID is missing or malformed
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+- **AND** no link is created
+
+### Requirement: Authenticated clients can list linked Specs
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/spec-links` to authenticated clients. It SHALL return a project-scoped, deterministically ordered page containing normalized Spec representations and exactly the top-level fields `scenarioId`, `projectId`, `specs`, `total`, `page`, `limit`, and `totalPages`.
+
+#### Scenario: List linked Specs
+- **WHEN** an authenticated client requests links for an existing scenario in the requested project
+- **THEN** the system returns only Specs linked to that scenario and belonging to that project
+- **AND** orders them by creation time descending and then ID descending
+
+#### Scenario: Scenario has no linked Specs
+- **WHEN** an authenticated client lists Spec links for an existing unlinked scenario
+- **THEN** the system returns HTTP 200 with an empty `specs` array and zero pagination totals
+
+### Requirement: Authenticated clients can remove Spec links safely
+The system SHALL expose `DELETE /api/v2/test-scenarios/{scenarioId}/spec-links/{specId}` to authenticated clients and SHALL require a valid `projectId` query parameter. Removing a link SHALL return an empty HTTP 204 response and SHALL NOT delete or modify either endpoint or any execution or issue record.
+
+#### Scenario: Remove an existing link
+- **WHEN** an authenticated client removes an existing same-project scenario/Spec link
+- **THEN** the system returns HTTP 204 with no response body
+- **AND** removes only that link row
+
+#### Scenario: Link does not exist in the requested context
+- **WHEN** the requested pair is absent or is not valid in the requested project context
+- **THEN** the system returns HTTP 404 with an `{ "error": string }` response
+- **AND** no scenario, Spec, Result, ResultError, Assumption, or Issue is modified
+
+### Requirement: Scenario Result history is aggregated across linked Specs
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/results` to authenticated clients. It SHALL return each Result whose database Spec record is linked to the scenario and whose Spec and Execution belong to the requested project. Each Result SHALL appear at most once and SHALL use the normalized public Result representation.
+
+#### Scenario: Results from multiple linked Specs are returned
+- **WHEN** an authenticated client requests Results for a scenario linked to several Specs with execution history
+- **THEN** the system returns only Results belonging to those linked Specs in the requested project
+- **AND** orders them by start time descending and then ID descending
+
+#### Scenario: Unlinked scenario has empty Result history
+- **WHEN** an authenticated client requests Results for an existing scenario with no linked Specs
+- **THEN** the system returns HTTP 200 with `linkedSpecCount` equal to 0, an empty `results` array, and zero pagination totals
+
+#### Scenario: Linked Specs have no Results
+- **WHEN** an authenticated client requests Results for a scenario with linked Specs that have no Results
+- **THEN** the system returns HTTP 200 with a positive `linkedSpecCount`, an empty `results` array, and zero pagination totals
+
+### Requirement: Observed Issues are derived and deduplicated
+The system SHALL expose `GET /api/v2/test-scenarios/{scenarioId}/issues` to authenticated clients. It SHALL derive Issues only through linked Specs, their Results, ResultErrors, and Assumptions. Every Issue reached through an Assumption SHALL be considered observed regardless of confirmation state, and each Issue SHALL appear at most once using the normalized public Issue representation.
+
+#### Scenario: Issues are derived through execution evidence
+- **WHEN** linked-Spec Results have ResultErrors whose Assumptions reference Issues
+- **THEN** the system returns those Issues without creating a direct scenario/Issue association
+
+#### Scenario: Issue reached through several paths is deduplicated
+- **WHEN** one Issue is referenced by multiple Assumptions, errors, Results, or linked Specs for the scenario
+- **THEN** the Issue appears once in the response
+- **AND** contributes one to the total count
+
+#### Scenario: Unconfirmed assumption contributes an observed Issue
+- **WHEN** an Issue is reached through an Assumption whose `isConfirmed` value is false
+- **THEN** the Issue is included in the observed-Issue response
+
+#### Scenario: Scenario has no observed Issues
+- **WHEN** a scenario is unlinked or none of its linked-Spec evidence reaches an Issue
+- **THEN** the system returns HTTP 200 with an empty `issues` array and zero pagination totals
+
+### Requirement: Evidence responses are independently and deterministically paginated
+The Result and Issue endpoints SHALL accept positive integer `page` and `limit` parameters, default page to 1, default limit to 30, and reject limits greater than 100. Each response SHALL contain exactly `scenarioId`, `projectId`, `linkedSpecCount`, its domain collection, `total`, `page`, `limit`, and `totalPages` as top-level fields. Item and count queries SHALL use the same project, link, and evidence predicates.
+
+#### Scenario: Explicit Result page is returned
+- **WHEN** an authenticated client requests a valid Result page and limit
+- **THEN** the system returns the corresponding deterministic Result slice
+- **AND** pagination totals describe all matching linked-Spec Results
+
+#### Scenario: Explicit Issue page is returned
+- **WHEN** an authenticated client requests a valid Issue page and limit
+- **THEN** the system returns the corresponding deterministic unique-Issue slice
+- **AND** pagination totals describe all matching observed Issues
+
+#### Scenario: Evidence pagination is invalid
+- **WHEN** page or limit is non-numeric, fractional, zero, negative, or limit exceeds 100
+- **THEN** the system returns HTTP 400 with an `{ "error": string }` response
+
+### Requirement: Link lifecycle does not own scenarios or execution evidence
+Removing a link SHALL remove only the association. Deleting a Test Scenario SHALL remove its link rows and the scenario while preserving linked Specs and all Results, ResultErrors, Assumptions, and Issues. Deleting a Spec through existing behavior SHALL remove its link rows and leave linked Test Scenarios intact.
+
+#### Scenario: Removing a link preserves all domain records
+- **WHEN** an authenticated client removes a scenario/Spec link with existing execution and issue evidence
+- **THEN** the scenario, Spec, Results, ResultErrors, Assumptions, and Issues remain unchanged
+
+#### Scenario: Deleting a linked scenario preserves evidence
+- **WHEN** an authenticated client deletes a Test Scenario that has one or more Spec links
+- **THEN** the system removes the scenario and its link rows
+- **AND** preserves every linked Spec, Result, ResultError, Assumption, and Issue
+
+#### Scenario: Deleting a linked Spec preserves scenarios
+- **WHEN** the existing Spec deletion behavior deletes a Spec linked to one or more scenarios
+- **THEN** the system removes the Spec link rows
+- **AND** preserves every linked Test Scenario
+
+### Requirement: Integration APIs require authentication and documented contracts
+All Spec-link and evidence routes SHALL use the existing JWT authentication middleware. OpenAPI SHALL document link and evidence request schemas, stable success envelopes, pagination constraints, bearer authentication, and applicable 400, 401, 404, 409, and 500 error responses using the common error schema. Integration orchestration SHALL be available through services reusable by REST and future MCP handlers.
+
+#### Scenario: Integration request is unauthenticated
+- **WHEN** a client calls any Spec-link or evidence route without a valid authentication token
+- **THEN** the system returns HTTP 401 with an `{ "error": string }` response
+- **AND** no link or evidence data is returned or mutated
+
+#### Scenario: OpenAPI document is generated
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** all five integration operations and their request and response schemas are present under the Test Scenarios tag

--- a/openspec/changes/integrate-test-scenarios-with-execution-evidence/tasks.md
+++ b/openspec/changes/integrate-test-scenarios-with-execution-evidence/tasks.md
@@ -1,0 +1,59 @@
+## 1. Persistence and Migration
+
+- [x] 1.1 Add the explicit `TestScenarioSpecLink` Prisma model, endpoint relations, composite primary key, cascading link foreign keys, and reverse Spec index.
+- [x] 1.2 Inspect existing Result, ResultError, and Assumption indexes against the planned evidence predicates and add only the missing supporting indexes.
+- [x] 1.3 Create and review the additive Prisma migration, including rollback implications and confirmation that it does not alter existing scenario or evidence rows.
+- [x] 1.4 Regenerate the Prisma client and add migration/schema regression coverage for link uniqueness, foreign keys, cascade behavior, and evidence indexes.
+
+## 2. Integration Contracts and Validation
+
+- [x] 2.1 Create header-compliant integration type/schema files with the repository new-file workflow and export them through the established type surface.
+- [x] 2.2 Define Zod schemas for scenario/spec identifiers, add-link input, project context, and defaulted page/limit queries capped at 100.
+- [x] 2.3 Define typed link, linked-Spec list, scenario-Result, and observed-Issue response envelopes with exact stable top-level fields.
+- [x] 2.4 Add a typed duplicate-link conflict error and extend controller error mapping without relying on message-string inspection.
+
+## 3. Link Model and Link Management Service
+
+- [x] 3.1 Implement link-model creation with database-enforced composite uniqueness and Prisma conflict translation support.
+- [x] 3.2 Implement project-scoped deterministic linked-Spec list/count queries and linked Spec-ID/count resolution helpers.
+- [x] 3.3 Implement composite link deletion that reports whether an association existed without deleting either endpoint.
+- [x] 3.4 Implement service-level add-link validation that resolves both scenario and Spec through the same requested project before insertion.
+- [x] 3.5 Implement paginated linked-Spec listing and safe remove-link behavior with typed not-found and conflict outcomes.
+- [x] 3.6 Add model and service tests for many-to-many cardinality, duplicate races, cross-project rejection, pagination, and isolated unlinking.
+
+## 4. Reusable Result and Issue Evidence Queries
+
+- [x] 4.1 Add a Result service/model entry point explicitly filtering by database Spec record IDs, requested project, and deterministic `startTime DESC, id DESC` ordering.
+- [x] 4.2 Ensure the Result evidence item/count predicates match, return normalized public Results, and enforce both Spec and Execution project scope.
+- [x] 4.3 Add an Issue service/model entry point that traverses Assumption → ResultError → Result for linked Spec record IDs and the requested project.
+- [x] 4.4 Ensure observed-Issue item/count queries return unique normalized Issues, include confirmed and unconfirmed Assumptions, and order by `createdAt DESC, id DESC`.
+- [x] 4.5 Add Result and Issue query tests for multiple Spec IDs, empty ID sets, project isolation, deterministic pagination, deduplication, and confirmation-independent observation.
+
+## 5. Scenario Integration Service and REST Routes
+
+- [x] 5.1 Implement `testScenarioIntegrationService` orchestration for linked Specs, aggregated Results, observed Issues, linked-Spec counts, and valid empty responses.
+- [x] 5.2 Implement controller handlers for add/list/remove links and Result/Issue evidence reads with shared validation and consistent status/error envelopes.
+- [x] 5.3 Register the five authenticated nested Test Scenario routes in the existing test-scenario router with safe ordering relative to `/:scenarioId`.
+- [x] 5.4 Add controller tests for request validation, response shapes, empty evidence states, 201/200/204 success behavior, and 400/404/409/500 mapping.
+- [x] 5.5 Add route tests for JWT protection, parameter/query/body handoff, duplicate conflicts, and cross-project rejection across all five operations.
+
+## 6. OpenAPI Contract
+
+- [x] 6.1 Add or reuse OpenAPI schemas for link input/output, normalized Specs, normalized Results, normalized Issues, and the three paginated integration envelopes.
+- [x] 6.2 Register all five operations with bearer security, pagination constraints, exact response shapes, and common 400/401/404/409/500 error contracts as applicable.
+- [x] 6.3 Add OpenAPI contract tests for operation presence, schema reuse, required context fields, limits, error documentation, and Test Scenarios tagging.
+
+## 7. Lifecycle and Workflow Regression Coverage
+
+- [x] 7.1 Add an integration workflow covering multiple scenarios linked to multiple Specs and independently paginated Result and Issue reads.
+- [x] 7.2 Add regression coverage proving link removal preserves both endpoints and all Results, ResultErrors, Assumptions, and Issues.
+- [x] 7.3 Extend scenario-deletion coverage to prove link rows are removed while Specs and all evidence remain unchanged.
+- [x] 7.4 Add Spec-deletion coverage proving link rows are removed and linked Test Scenarios survive under existing Spec deletion semantics.
+- [x] 7.5 Run focused MVC-boundary, Prisma-migration, OpenAPI-contract, and Jest-pattern reviews and resolve identified drift.
+
+## 8. Verification
+
+- [x] 8.1 Run `npm run type-check` and resolve all strict TypeScript errors.
+- [x] 8.2 Run `npm run lint` and resolve all ESLint or license-header violations.
+- [x] 8.3 Run `npm test` and confirm the complete Jest suite passes.
+- [x] 8.4 Run `npm run build` and confirm the production build succeeds.

--- a/prisma/migrations/20260824120000_add_test_scenarios/migration.sql
+++ b/prisma/migrations/20260824120000_add_test_scenarios/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "TestScenario" (
+    "id" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "contentMd" TEXT NOT NULL,
+    "createdById" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+
+    CONSTRAINT "TestScenario_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TestScenario_projectId_idx" ON "TestScenario"("projectId");
+
+-- CreateIndex
+CREATE INDEX "TestScenario_projectId_createdAt_idx" ON "TestScenario"("projectId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "TestScenario_createdById_idx" ON "TestScenario"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "TestScenario" ADD CONSTRAINT "TestScenario_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestScenario" ADD CONSTRAINT "TestScenario_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql
+++ b/prisma/migrations/20260826120000_add_test_scenario_spec_links/migration.sql
@@ -1,0 +1,22 @@
+-- Additive scenario/Spec association only. Existing scenarios and evidence are untouched.
+CREATE TABLE "TestScenarioSpecLink" (
+    "testScenarioId" UUID NOT NULL,
+    "specId" UUID NOT NULL,
+
+    CONSTRAINT "TestScenarioSpecLink_pkey" PRIMARY KEY ("testScenarioId", "specId")
+);
+
+CREATE INDEX "TestScenarioSpecLink_specId_idx" ON "TestScenarioSpecLink"("specId");
+
+ALTER TABLE "TestScenarioSpecLink"
+    ADD CONSTRAINT "TestScenarioSpecLink_testScenarioId_fkey"
+    FOREIGN KEY ("testScenarioId") REFERENCES "TestScenario"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "TestScenarioSpecLink"
+    ADD CONSTRAINT "TestScenarioSpecLink_specId_fkey"
+    FOREIGN KEY ("specId") REFERENCES "Spec"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "Result_specId_startTime_idx" ON "Result"("specId", "startTime");
+CREATE INDEX "ResultError_resultId_idx" ON "ResultError"("resultId");
+CREATE INDEX "Assumption_issueId_idx" ON "Assumption"("issueId");
+CREATE INDEX "Assumption_resultErrorId_idx" ON "Assumption"("resultErrorId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Project {
   executions    Execution[]
   specs         Spec[]
   issues        Issue[]
+  testScenarios TestScenario[]
   uploadApiKeys UploadApiKey[]
   dailyMetrics  DailyExecutionMetric[]
 
@@ -171,10 +172,11 @@ model User {
   analyzeEnabled          Boolean  @default(false)
 
   // Project relationships
-  projects      Project[]
-  issuesCreated Issue[]        @relation("IssuesCreated")
-  issuesUpdated Issue[]        @relation("IssuesUpdated")
-  uploadApiKeys UploadApiKey[]
+  projects             Project[]
+  issuesCreated        Issue[]        @relation("IssuesCreated")
+  issuesUpdated        Issue[]        @relation("IssuesUpdated")
+  testScenariosCreated TestScenario[] @relation("TestScenarioCreatedBy")
+  uploadApiKeys        UploadApiKey[]
 }
 
 model Issue {
@@ -201,6 +203,23 @@ model Issue {
   @@index([projectId])
   @@index([projectId, category])
   @@index([projectId, createdAt])
+}
+
+model TestScenario {
+  id          String   @id @default(uuid()) @db.Uuid
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  title       String
+  contentMd   String   @db.Text
+  createdById String   @db.Uuid
+
+  project   Project @relation(fields: [projectId], references: [id])
+  projectId String  @db.Uuid
+  createdBy User    @relation("TestScenarioCreatedBy", fields: [createdById], references: [id])
+
+  @@index([projectId])
+  @@index([projectId, createdAt])
+  @@index([createdById])
 }
 
 model UploadApiKey {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,7 @@ model Spec {
   projectId String  @db.Uuid
 
   results Result[]
+  testScenarioLinks TestScenarioSpecLink[]
 
   // Unique key per project
   @@unique([projectId, key])
@@ -122,6 +123,8 @@ model Result {
   analysisFeedbackCategory        String?
   analysisFeedbackConfidence      Int?
   analysisFeedbackConclusion      String?
+
+  @@index([specId, startTime])
 }
 
 model ResultError {
@@ -139,6 +142,8 @@ model ResultError {
   result          Result?      @relation(fields: [resultId], references: [id])
   resultId        String?      @db.Uuid
   assumptions     Assumption[]
+
+  @@index([resultId])
 }
 
 model Assumption {
@@ -152,6 +157,9 @@ model Assumption {
   issueId       String       @db.Uuid
   resultError   ResultError? @relation(fields: [resultErrorId], references: [id])
   resultErrorId String?      @db.Uuid
+
+  @@index([issueId])
+  @@index([resultErrorId])
 }
 
 model User {
@@ -217,9 +225,22 @@ model TestScenario {
   projectId String  @db.Uuid
   createdBy User    @relation("TestScenarioCreatedBy", fields: [createdById], references: [id])
 
+  specLinks TestScenarioSpecLink[]
+
   @@index([projectId])
   @@index([projectId, createdAt])
   @@index([createdById])
+}
+
+model TestScenarioSpecLink {
+  testScenarioId String @db.Uuid
+  specId         String @db.Uuid
+
+  testScenario TestScenario @relation(fields: [testScenarioId], references: [id], onDelete: Cascade)
+  spec         Spec         @relation(fields: [specId], references: [id], onDelete: Cascade)
+
+  @@id([testScenarioId, specId])
+  @@index([specId])
 }
 
 model UploadApiKey {

--- a/src/controllers/testScenarioController.ts
+++ b/src/controllers/testScenarioController.ts
@@ -8,6 +8,7 @@ import {
   testScenarioIdParamsSchema,
   testScenarioListQuerySchema,
   testScenarioProjectQuerySchema,
+  updateTestScenarioSchema,
 } from "@/schemas/testScenarioSchemas";
 import {
   testScenarioEvidenceParamsSchema as integrationEvidenceParamsSchema,
@@ -127,6 +128,40 @@ export const testScenarioController = {
       res.status(200).json(scenario);
     } catch (error) {
       sendServiceError(res, error, "fetch test scenario");
+    }
+  },
+
+  async update(
+    req: Request<{ scenarioId: string }>,
+    res: Response,
+  ): Promise<void> {
+    const params = testScenarioIdParamsSchema.safeParse(req.params);
+    const query = testScenarioProjectQuerySchema.safeParse(req.query);
+    const body = updateTestScenarioSchema.safeParse(req.body);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    if (!body.success) {
+      sendValidationError(res, validationMessage(body.error));
+      return;
+    }
+
+    try {
+      const scenario = await testScenarioService.updateScenario({
+        scenarioId: params.data.scenarioId,
+        projectId: query.data.projectId,
+        ...body.data,
+      });
+      res.status(200).json(scenario);
+    } catch (error) {
+      sendServiceError(res, error, "update test scenario");
     }
   },
 

--- a/src/controllers/testScenarioController.ts
+++ b/src/controllers/testScenarioController.ts
@@ -1,0 +1,133 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Request, Response } from "express";
+import type { AuthenticatedRequest } from "@/middleware/authMiddleware";
+import {
+  createTestScenarioSchema,
+  testScenarioIdParamsSchema,
+  testScenarioListQuerySchema,
+  testScenarioProjectQuerySchema,
+} from "@/schemas/testScenarioSchemas";
+import { testScenarioService } from "@/services/testScenarioService";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+} from "@/types/testScenarios";
+
+function validationMessage(error: { issues: Array<{ message: string }> }): string {
+  return error.issues[0]?.message ?? "Invalid request";
+}
+
+function sendValidationError(res: Response, message: string): void {
+  res.status(400).json({ error: message });
+}
+
+function sendServiceError(res: Response, error: unknown, operation: string): void {
+  if (error instanceof TestScenarioValidationError) {
+    res.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (error instanceof TestScenarioNotFoundError) {
+    res.status(404).json({ error: error.message });
+    return;
+  }
+
+  const message = error instanceof Error ? error.message : "Unknown error";
+  res.status(500).json({ error: `Failed to ${operation}. ${message}` });
+}
+
+export const testScenarioController = {
+  async create(req: AuthenticatedRequest, res: Response): Promise<void> {
+    if (!req.user) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    const parsed = createTestScenarioSchema.safeParse(req.body);
+    if (!parsed.success) {
+      sendValidationError(res, validationMessage(parsed.error));
+      return;
+    }
+
+    try {
+      const scenario = await testScenarioService.createScenario({
+        ...parsed.data,
+        createdById: req.user.id,
+      });
+      res.status(201).json(scenario);
+    } catch (error) {
+      sendServiceError(res, error, "create test scenario");
+    }
+  },
+
+  async list(req: Request, res: Response): Promise<void> {
+    const parsed = testScenarioListQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      sendValidationError(res, validationMessage(parsed.error));
+      return;
+    }
+
+    try {
+      const response = await testScenarioService.listScenarios(parsed.data);
+      res.status(200).json(response);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenarios");
+    }
+  },
+
+  async getById(
+    req: Request<{ scenarioId: string }>,
+    res: Response,
+  ): Promise<void> {
+    const params = testScenarioIdParamsSchema.safeParse(req.params);
+    const query = testScenarioProjectQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const scenario = await testScenarioService.getScenarioById(
+        params.data.scenarioId,
+        query.data.projectId,
+      );
+      res.status(200).json(scenario);
+    } catch (error) {
+      sendServiceError(res, error, "fetch test scenario");
+    }
+  },
+
+  async delete(
+    req: Request<{ scenarioId: string }>,
+    res: Response,
+  ): Promise<void> {
+    const params = testScenarioIdParamsSchema.safeParse(req.params);
+    const query = testScenarioProjectQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      await testScenarioService.deleteScenario(
+        params.data.scenarioId,
+        query.data.projectId,
+      );
+      res.status(204).send();
+    } catch (error) {
+      sendServiceError(res, error, "delete test scenario");
+    }
+  },
+};

--- a/src/controllers/testScenarioController.ts
+++ b/src/controllers/testScenarioController.ts
@@ -9,11 +9,26 @@ import {
   testScenarioListQuerySchema,
   testScenarioProjectQuerySchema,
 } from "@/schemas/testScenarioSchemas";
+import {
+  testScenarioEvidenceParamsSchema as integrationEvidenceParamsSchema,
+  testScenarioEvidenceQuerySchema as integrationEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema as integrationSpecLinkBodySchema,
+  testScenarioSpecLinkDeleteParamsSchema as integrationSpecLinkDeleteParamsSchema,
+  testScenarioSpecLinkListQuerySchema as integrationSpecLinkListQuerySchema,
+  testScenarioSpecLinkParamsSchema as integrationSpecLinkParamsSchema,
+  testScenarioSpecLinkQuerySchema as integrationSpecLinkQuerySchema,
+} from "@/schemas/testScenarioIntegrationSchemas";
 import { testScenarioService } from "@/services/testScenarioService";
+import { testScenarioIntegrationService } from "@/services/testScenarioIntegrationService";
 import {
   TestScenarioNotFoundError,
   TestScenarioValidationError,
 } from "@/types/testScenarios";
+import {
+  TestScenarioIntegrationValidationError,
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+} from "@/types/testScenarioIntegration";
 
 function validationMessage(error: { issues: Array<{ message: string }> }): string {
   return error.issues[0]?.message ?? "Invalid request";
@@ -24,13 +39,24 @@ function sendValidationError(res: Response, message: string): void {
 }
 
 function sendServiceError(res: Response, error: unknown, operation: string): void {
-  if (error instanceof TestScenarioValidationError) {
+  if (
+    error instanceof TestScenarioValidationError ||
+    error instanceof TestScenarioIntegrationValidationError
+  ) {
     res.status(400).json({ error: error.message });
     return;
   }
 
-  if (error instanceof TestScenarioNotFoundError) {
+  if (
+    error instanceof TestScenarioNotFoundError ||
+    error instanceof TestScenarioSpecLinkNotFoundError
+  ) {
     res.status(404).json({ error: error.message });
+    return;
+  }
+
+  if (error instanceof TestScenarioSpecLinkConflictError) {
+    res.status(409).json({ error: error.message });
     return;
   }
 
@@ -128,6 +154,134 @@ export const testScenarioController = {
       res.status(204).send();
     } catch (error) {
       sendServiceError(res, error, "delete test scenario");
+    }
+  },
+
+  async addSpecLink(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkQuerySchema.safeParse(req.query);
+    const body = integrationSpecLinkBodySchema.safeParse(req.body);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    if (!body.success) {
+      sendValidationError(res, validationMessage(body.error));
+      return;
+    }
+
+    try {
+      const link = await testScenarioIntegrationService.addSpecLink({
+        scenarioId: params.data.scenarioId,
+        projectId: query.data.projectId,
+        specId: body.data.specId,
+      });
+      res.status(201).json(link);
+    } catch (error) {
+      sendServiceError(res, error, "link Spec to test scenario");
+    }
+  },
+
+  async listSpecLinks(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkListQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const links = await testScenarioIntegrationService.listSpecLinks({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(links);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Spec links");
+    }
+  },
+
+  async removeSpecLink(req: Request, res: Response): Promise<void> {
+    const params = integrationSpecLinkDeleteParamsSchema.safeParse(req.params);
+    const query = integrationSpecLinkQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      await testScenarioIntegrationService.removeSpecLink({
+        scenarioId: params.data.scenarioId,
+        specId: params.data.specId,
+        projectId: query.data.projectId,
+      });
+      res.status(204).send();
+    } catch (error) {
+      sendServiceError(res, error, "remove test scenario Spec link");
+    }
+  },
+
+  async getResults(req: Request, res: Response): Promise<void> {
+    const params = integrationEvidenceParamsSchema.safeParse(req.params);
+    const query = integrationEvidenceQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const results = await testScenarioIntegrationService.getResults({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(results);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Results");
+    }
+  },
+
+  async getIssues(req: Request, res: Response): Promise<void> {
+    const params = integrationEvidenceParamsSchema.safeParse(req.params);
+    const query = integrationEvidenceQuerySchema.safeParse(req.query);
+    if (!params.success) {
+      sendValidationError(res, validationMessage(params.error));
+      return;
+    }
+
+    if (!query.success) {
+      sendValidationError(res, validationMessage(query.error));
+      return;
+    }
+
+    try {
+      const issues = await testScenarioIntegrationService.getIssues({
+        scenarioId: params.data.scenarioId,
+        ...query.data,
+      });
+      res.status(200).json(issues);
+    } catch (error) {
+      sendServiceError(res, error, "list test scenario Issues");
     }
   },
 };

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -26,6 +26,7 @@ import { registerCtrfRoutes } from "./ctrf";
 import { registerUploadApiKeyRoutes } from "./uploadApiKey";
 import { registerAnalysisExportRoutes } from "./analysisExport";
 import { registerPdfExportRoutes } from "./pdfExport";
+import { registerTestScenarioRoutes } from "./testScenarios";
 import "./zod";
 
 export function generateOpenAPISpec() {
@@ -51,6 +52,7 @@ export function generateOpenAPISpec() {
   registerUploadApiKeyRoutes(registry);
   registerAnalysisExportRoutes(registry);
   registerPdfExportRoutes(registry);
+  registerTestScenarioRoutes(registry);
 
   const generator = new OpenApiGeneratorV31(registry.definitions);
 
@@ -87,6 +89,10 @@ export function generateOpenAPISpec() {
       {
         name: "Specs",
         description: "Test specification endpoints",
+      },
+      {
+        name: "Test Scenarios",
+        description: "Project-scoped authored Markdown test scenario endpoints",
       },
       {
         name: "Assumptions",

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -1,0 +1,255 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
+import { ErrorResponseSchema } from "./common";
+import { z } from "./zod";
+
+const TestScenarioSchema = z
+  .object({
+    id: z.string().uuid(),
+    projectId: z.string().uuid(),
+    createdById: z.string().uuid(),
+    title: z.string(),
+    contentMd: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("TestScenario");
+
+const CreateTestScenarioRequestSchema = z
+  .object({
+    projectId: z.string().uuid(),
+    title: z.string().min(1),
+    contentMd: z.string().min(1),
+  })
+  .openapi("CreateTestScenarioRequest");
+
+const TestScenarioIdParamsSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+  })
+  .openapi("TestScenarioIdParams");
+
+const TestScenarioProjectQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+  })
+  .openapi("TestScenarioProjectQuery");
+
+const TestScenarioListQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioListQuery");
+
+const TestScenarioListResponseSchema = z
+  .object({
+    scenarios: z.array(TestScenarioSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioListResponse");
+
+export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
+  registry.register("TestScenario", TestScenarioSchema);
+  registry.register(
+    "CreateTestScenarioRequest",
+    CreateTestScenarioRequestSchema,
+  );
+  registry.register("TestScenarioIdParams", TestScenarioIdParamsSchema);
+  registry.register(
+    "TestScenarioProjectQuery",
+    TestScenarioProjectQuerySchema,
+  );
+  registry.register("TestScenarioListQuery", TestScenarioListQuerySchema);
+  registry.register(
+    "TestScenarioListResponse",
+    TestScenarioListResponseSchema,
+  );
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v2/test-scenarios",
+    description: "Creates a project-scoped Markdown test scenario.",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: CreateTestScenarioRequestSchema,
+          },
+        },
+      },
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      201: {
+        description: "Test scenario created",
+        content: {
+          "application/json": { schema: TestScenarioSchema },
+        },
+      },
+      400: {
+        description: "Invalid test scenario input",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Project not found",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios",
+    description: "Lists project-scoped Markdown test scenarios.",
+    request: {
+      query: TestScenarioListQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated test scenarios",
+        content: {
+          "application/json": { schema: TestScenarioListResponseSchema },
+        },
+      },
+      400: {
+        description: "Invalid project or pagination query",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}",
+    description: "Retrieves a test scenario within a project context.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Test scenario details",
+        content: {
+          "application/json": { schema: TestScenarioSchema },
+        },
+      },
+      400: {
+        description: "Invalid scenario or project identifier",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Test scenario not found in the requested project",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/v2/test-scenarios/{scenarioId}",
+    description: "Deletes a test scenario within a project context.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      204: {
+        description: "Test scenario deleted",
+      },
+      400: {
+        description: "Invalid scenario or project identifier",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      401: {
+        description: "Unauthorized",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      404: {
+        description: "Test scenario not found in the requested project",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+      500: {
+        description: "Internal server error",
+        content: {
+          "application/json": { schema: ErrorResponseSchema },
+        },
+      },
+    },
+    tags: ["Test Scenarios"],
+  });
+}
+
+export {
+  CreateTestScenarioRequestSchema,
+  TestScenarioIdParamsSchema,
+  TestScenarioListQuerySchema,
+  TestScenarioListResponseSchema,
+  TestScenarioProjectQuerySchema,
+  TestScenarioSchema,
+};

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -3,6 +3,7 @@
 
 import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi";
 import { ErrorResponseSchema } from "./common";
+import { ResultSchema } from "./results";
 import { z } from "./zod";
 
 const TestScenarioSchema = z
@@ -55,6 +56,124 @@ const TestScenarioListResponseSchema = z
   })
   .openapi("TestScenarioListResponse");
 
+const TestScenarioSpecLinkBodySchema = z
+  .object({
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkBody");
+
+const TestScenarioSpecLinkResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkResponse");
+
+const TestScenarioLinkedSpecSchema = z
+  .object({
+    id: z.string().uuid(),
+    projectId: z.string().uuid(),
+    key: z.string(),
+    file: z.string(),
+    title: z.string(),
+    tags: z.array(z.string()),
+    annotations: z.array(z.unknown()),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .openapi("TestScenarioLinkedSpec");
+
+const TestScenarioSpecLinkListQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioSpecLinkListQuery");
+
+const TestScenarioSpecLinkDeleteParamsSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    specId: z.string().uuid(),
+  })
+  .openapi("TestScenarioSpecLinkDeleteParams");
+
+const TestScenarioEvidenceQuerySchema = z
+  .object({
+    projectId: z.string().uuid(),
+    page: z.number().int().min(1).default(1).optional(),
+    limit: z.number().int().min(1).max(100).default(30).optional(),
+  })
+  .openapi("TestScenarioEvidenceQuery");
+
+const TestScenarioSpecLinkListResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    specs: z.array(TestScenarioLinkedSpecSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioSpecLinkListResponse");
+
+const TestScenarioObservedIssueSchema = z
+  .object({
+    id: z.string().uuid(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    name: z.string(),
+    category: z.string(),
+    description: z.string().nullable(),
+    portal: z.string().nullable(),
+    service: z.string().nullable(),
+    ticket: z.string().nullable(),
+    createdBy: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        email: z.string(),
+        createdAt: z.string(),
+      })
+      .nullable(),
+    updatedBy: z
+      .object({
+        id: z.string().uuid(),
+        name: z.string(),
+        email: z.string(),
+        createdAt: z.string(),
+      })
+      .nullable(),
+  })
+  .openapi("TestScenarioObservedIssue");
+
+const TestScenarioResultsResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    linkedSpecCount: z.number().int().nonnegative(),
+    results: z.array(ResultSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioResultsResponse");
+
+const TestScenarioIssuesResponseSchema = z
+  .object({
+    scenarioId: z.string().uuid(),
+    projectId: z.string().uuid(),
+    linkedSpecCount: z.number().int().nonnegative(),
+    issues: z.array(TestScenarioObservedIssueSchema),
+    total: z.number().int().nonnegative(),
+    page: z.number().int().positive(),
+    limit: z.number().int().positive().max(100),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .openapi("TestScenarioIssuesResponse");
+
 export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
   registry.register("TestScenario", TestScenarioSchema);
   registry.register(
@@ -71,6 +190,174 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
     "TestScenarioListResponse",
     TestScenarioListResponseSchema,
   );
+  registry.register(
+    "TestScenarioSpecLinkBody",
+    TestScenarioSpecLinkBodySchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkResponse",
+    TestScenarioSpecLinkResponseSchema,
+  );
+  registry.register(
+    "TestScenarioLinkedSpec",
+    TestScenarioLinkedSpecSchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkListQuery",
+    TestScenarioSpecLinkListQuerySchema,
+  );
+  registry.register(
+    "TestScenarioSpecLinkDeleteParams",
+    TestScenarioSpecLinkDeleteParamsSchema,
+  );
+  registry.register("TestScenarioEvidenceQuery", TestScenarioEvidenceQuerySchema);
+  registry.register(
+    "TestScenarioSpecLinkListResponse",
+    TestScenarioSpecLinkListResponseSchema,
+  );
+  registry.register(
+    "TestScenarioObservedIssue",
+    TestScenarioObservedIssueSchema,
+  );
+  registry.register(
+    "TestScenarioResultsResponse",
+    TestScenarioResultsResponseSchema,
+  );
+  registry.register(
+    "TestScenarioIssuesResponse",
+    TestScenarioIssuesResponseSchema,
+  );
+
+  const errorResponse = (description: string) => ({
+    description,
+    content: {
+      "application/json": { schema: ErrorResponseSchema },
+    },
+  });
+
+  registry.registerPath({
+    method: "post",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links",
+    description: "Links a project-local Spec to a test scenario.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+      body: {
+        required: true,
+        content: {
+          "application/json": { schema: TestScenarioSpecLinkBodySchema },
+        },
+      },
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      201: {
+        description: "Test scenario Spec link created",
+        content: {
+          "application/json": { schema: TestScenarioSpecLinkResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or Spec link input"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario or Spec not found in the project"),
+      409: errorResponse("The scenario/Spec link already exists"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links",
+    description: "Lists Specs linked to a test scenario.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioSpecLinkListQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated linked Specs",
+        content: {
+          "application/json": {
+            schema: TestScenarioSpecLinkListResponseSchema,
+          },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "delete",
+    path: "/api/v2/test-scenarios/{scenarioId}/spec-links/{specId}",
+    description: "Removes a Spec link without deleting either endpoint.",
+    request: {
+      params: TestScenarioSpecLinkDeleteParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      204: { description: "Test scenario Spec link removed" },
+      400: errorResponse("Invalid scenario, project, or Spec identifier"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario Spec link not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/results",
+    description: "Lists paginated execution Results across linked Specs.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioEvidenceQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated scenario Result evidence",
+        content: {
+          "application/json": { schema: TestScenarioResultsResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "get",
+    path: "/api/v2/test-scenarios/{scenarioId}/issues",
+    description: "Lists paginated observed Issues across linked Specs.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioEvidenceQuerySchema,
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Paginated scenario Issue evidence",
+        content: {
+          "application/json": { schema: TestScenarioIssuesResponseSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or pagination query"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the project"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
 
   registry.registerPath({
     method: "post",
@@ -247,9 +534,19 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
 
 export {
   CreateTestScenarioRequestSchema,
+  TestScenarioEvidenceQuerySchema,
   TestScenarioIdParamsSchema,
+  TestScenarioIssuesResponseSchema,
+  TestScenarioLinkedSpecSchema,
   TestScenarioListQuerySchema,
   TestScenarioListResponseSchema,
+  TestScenarioObservedIssueSchema,
   TestScenarioProjectQuerySchema,
+  TestScenarioResultsResponseSchema,
+  TestScenarioSpecLinkBodySchema,
+  TestScenarioSpecLinkDeleteParamsSchema,
+  TestScenarioSpecLinkListQuerySchema,
+  TestScenarioSpecLinkListResponseSchema,
+  TestScenarioSpecLinkResponseSchema,
   TestScenarioSchema,
 };

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -26,6 +26,23 @@ const CreateTestScenarioRequestSchema = z
   })
   .openapi("CreateTestScenarioRequest");
 
+const UpdateTestScenarioRequestSchema = z
+  .union([
+    z
+      .object({
+        title: z.string().min(1).regex(/\S/),
+        contentMd: z.string().min(1).optional(),
+      })
+      .strict(),
+    z
+      .object({
+        title: z.string().min(1).regex(/\S/).optional(),
+        contentMd: z.string().min(1),
+      })
+      .strict(),
+  ])
+  .openapi("UpdateTestScenarioRequest");
+
 const TestScenarioIdParamsSchema = z
   .object({
     scenarioId: z.string().uuid(),
@@ -180,6 +197,10 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
     "CreateTestScenarioRequest",
     CreateTestScenarioRequestSchema,
   );
+  registry.register(
+    "UpdateTestScenarioRequest",
+    UpdateTestScenarioRequestSchema,
+  );
   registry.register("TestScenarioIdParams", TestScenarioIdParamsSchema);
   registry.register(
     "TestScenarioProjectQuery",
@@ -261,6 +282,37 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
       401: errorResponse("Unauthorized"),
       404: errorResponse("Test scenario or Spec not found in the project"),
       409: errorResponse("The scenario/Spec link already exists"),
+      500: errorResponse("Internal server error"),
+    },
+    tags: ["Test Scenarios"],
+  });
+
+  registry.registerPath({
+    method: "patch",
+    path: "/api/v2/test-scenarios/{scenarioId}",
+    description:
+      "Partially updates a test scenario within a project context. Omitted fields are preserved.",
+    request: {
+      params: TestScenarioIdParamsSchema,
+      query: TestScenarioProjectQuerySchema,
+      body: {
+        required: true,
+        content: {
+          "application/json": { schema: UpdateTestScenarioRequestSchema },
+        },
+      },
+    },
+    security: [{ BearerAuth: [] }],
+    responses: {
+      200: {
+        description: "Updated test scenario details",
+        content: {
+          "application/json": { schema: TestScenarioSchema },
+        },
+      },
+      400: errorResponse("Invalid scenario, project, or update input"),
+      401: errorResponse("Unauthorized"),
+      404: errorResponse("Test scenario not found in the requested project"),
       500: errorResponse("Internal server error"),
     },
     tags: ["Test Scenarios"],
@@ -534,6 +586,7 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
 
 export {
   CreateTestScenarioRequestSchema,
+  UpdateTestScenarioRequestSchema,
   TestScenarioEvidenceQuerySchema,
   TestScenarioIdParamsSchema,
   TestScenarioIssuesResponseSchema,

--- a/src/models/issueModel.ts
+++ b/src/models/issueModel.ts
@@ -93,6 +93,71 @@ export const issueModel = {
     });
   },
 
+  findObservedBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+    page = 1,
+    limit = 30,
+  ): Promise<PrismaIssueWithUsers[]> => {
+    if (specRecordIds.length === 0) {
+      return [];
+    }
+
+    return (await dbClient.issue.findMany({
+      where: {
+        projectId,
+        assumptions: {
+          some: {
+            resultError: {
+              result: {
+                spec: {
+                  id: { in: specRecordIds },
+                  projectId,
+                },
+                execution: { projectId },
+              },
+            },
+          },
+        },
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      include: {
+        createdBy: true,
+        updatedBy: true,
+      },
+    })) as PrismaIssueWithUsers[];
+  },
+
+  countObservedBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+  ): Promise<number> => {
+    if (specRecordIds.length === 0) {
+      return 0;
+    }
+
+    return await dbClient.issue.count({
+      where: {
+        projectId,
+        assumptions: {
+          some: {
+            resultError: {
+              result: {
+                spec: {
+                  id: { in: specRecordIds },
+                  projectId,
+                },
+                execution: { projectId },
+              },
+            },
+          },
+        },
+      },
+    });
+  },
+
   findById: async (
     id: string,
     projectId: string,

--- a/src/models/projectModel.ts
+++ b/src/models/projectModel.ts
@@ -108,6 +108,19 @@ export const projectModel = {
     });
   },
 
+  async exists(
+    id: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<boolean> {
+    const client = tx ?? dbClient;
+    const project = await client.project.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+
+    return project !== null;
+  },
+
   async create(
     data: {
       name: string;
@@ -201,9 +214,10 @@ export const projectModel = {
    * 4. Issues (references Project)
    * 5. Executions (references Project)
    * 6. Specs (references Project)
-   * 7. DailyExecutionMetric (references Project)
-   * 8. UploadApiKeys (references Project)
-   * 9. Project itself
+   * 7. TestScenarios (references Project)
+   * 8. DailyExecutionMetric (references Project)
+   * 9. UploadApiKeys (references Project)
+   * 10. Project itself
    */
   async deleteWithCascade(id: string): Promise<Project> {
     return await dbClient.$transaction(async (tx) => {
@@ -301,17 +315,22 @@ export const projectModel = {
         where: { projectId: id },
       });
 
-      // Step 7: Delete DailyExecutionMetric (references Project)
+      // Step 7: Delete TestScenarios (references Project)
+      await tx.testScenario.deleteMany({
+        where: { projectId: id },
+      });
+
+      // Step 8: Delete DailyExecutionMetric (references Project)
       await tx.dailyExecutionMetric.deleteMany({
         where: { projectId: id },
       });
 
-      // Step 8: Delete UploadApiKeys (references Project)
+      // Step 9: Delete UploadApiKeys (references Project)
       await tx.uploadApiKey.deleteMany({
         where: { projectId: id },
       });
 
-      // Step 9: Delete Project itself
+      // Step 10: Delete Project itself
       return await tx.project.delete({
         where: { id },
       });

--- a/src/models/resultModel.ts
+++ b/src/models/resultModel.ts
@@ -319,6 +319,62 @@ export const resultModel = {
     });
   },
 
+  findManyBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+    page = 1,
+    limit = 30,
+  ): Promise<ResultWithRelations[]> => {
+    if (specRecordIds.length === 0) {
+      return [];
+    }
+
+    return (await dbClient.result.findMany({
+      where: {
+        spec: {
+          id: { in: specRecordIds },
+          projectId,
+        },
+        execution: { projectId },
+      },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ startTime: "desc" }, { id: "desc" }],
+      include: {
+        spec: true,
+        execution: true,
+        errors: {
+          include: {
+            assumptions: {
+              include: {
+                issue: true,
+              },
+            },
+          },
+        },
+      },
+    })) as unknown as ResultWithRelations[];
+  },
+
+  countBySpecRecordIds: async (
+    specRecordIds: string[],
+    projectId: string,
+  ): Promise<number> => {
+    if (specRecordIds.length === 0) {
+      return 0;
+    }
+
+    return await dbClient.result.count({
+      where: {
+        spec: {
+          id: { in: specRecordIds },
+          projectId,
+        },
+        execution: { projectId },
+      },
+    });
+  },
+
   findSpecTags: async (filters: ResultFilters): Promise<Prisma.JsonValue[]> => {
     const resultWhere = buildResultWhereClause(filters);
     const { spec, ...matchingResultWhere } = resultWhere;

--- a/src/models/testScenarioModel.ts
+++ b/src/models/testScenarioModel.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Prisma, TestScenario } from "@prisma/client";
+import { dbClient } from "@/prisma/client";
+
+export interface CreateTestScenarioData {
+  projectId: string;
+  title: string;
+  contentMd: string;
+  createdById: string;
+}
+
+const projectWhere = (projectId: string): Prisma.TestScenarioWhereInput => ({
+  projectId,
+});
+
+export const testScenarioModel = {
+  async create(
+    data: CreateTestScenarioData,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.create({ data });
+  },
+
+  async findMany(
+    projectId: string,
+    page = 1,
+    limit = 30,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario[]> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.findMany({
+      where: projectWhere(projectId),
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    });
+  },
+
+  async count(
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.count({
+      where: projectWhere(projectId),
+    });
+  },
+
+  async findById(
+    id: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario | null> {
+    const client = tx ?? dbClient;
+    return await client.testScenario.findFirst({
+      where: { id, projectId },
+    });
+  },
+
+  async delete(
+    id: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    const result = await client.testScenario.deleteMany({
+      where: { id, projectId },
+    });
+
+    return result.count;
+  },
+};

--- a/src/models/testScenarioModel.ts
+++ b/src/models/testScenarioModel.ts
@@ -11,6 +11,11 @@ export interface CreateTestScenarioData {
   createdById: string;
 }
 
+export interface UpdateTestScenarioData {
+  title?: string;
+  contentMd?: string;
+}
+
 const projectWhere = (projectId: string): Prisma.TestScenarioWhereInput => ({
   projectId,
 });
@@ -58,6 +63,36 @@ export const testScenarioModel = {
     return await client.testScenario.findFirst({
       where: { id, projectId },
     });
+  },
+
+  async update(
+    id: string,
+    projectId: string,
+    data: UpdateTestScenarioData,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenario | null> {
+    const updateWithinTransaction = async (
+      client: Prisma.TransactionClient,
+    ): Promise<TestScenario | null> => {
+      const scenario = await client.testScenario.findFirst({
+        where: { id, projectId },
+      });
+
+      if (!scenario) {
+        return null;
+      }
+
+      return await client.testScenario.update({
+        where: { id: scenario.id },
+        data,
+      });
+    };
+
+    if (tx) {
+      return await updateWithinTransaction(tx);
+    }
+
+    return await dbClient.$transaction(updateWithinTransaction);
   },
 
   async delete(

--- a/src/models/testScenarioSpecLinkModel.ts
+++ b/src/models/testScenarioSpecLinkModel.ts
@@ -1,0 +1,86 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  Prisma,
+  Spec,
+  TestScenarioSpecLink,
+} from "@prisma/client";
+import { dbClient } from "@/prisma/client";
+
+export type TestScenarioSpecLinkWithSpec = TestScenarioSpecLink & {
+  spec: Spec;
+};
+
+const linkedSpecWhere = (
+  scenarioId: string,
+  projectId: string,
+): Prisma.TestScenarioSpecLinkWhereInput => ({
+  testScenarioId: scenarioId,
+  spec: { projectId },
+});
+
+export const testScenarioSpecLinkModel = {
+  async create(
+    data: { testScenarioId: string; specId: string },
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenarioSpecLink> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.create({ data });
+  },
+
+  async findLinkedSpecs(
+    scenarioId: string,
+    projectId: string,
+    page = 1,
+    limit = 30,
+    tx?: Prisma.TransactionClient,
+  ): Promise<TestScenarioSpecLinkWithSpec[]> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.findMany({
+      where: linkedSpecWhere(scenarioId, projectId),
+      include: { spec: true },
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: [{ spec: { createdAt: "desc" } }, { spec: { id: "desc" } }],
+    });
+  },
+
+  async countLinkedSpecs(
+    scenarioId: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    return await client.testScenarioSpecLink.count({
+      where: linkedSpecWhere(scenarioId, projectId),
+    });
+  },
+
+  async findLinkedSpecIds(
+    scenarioId: string,
+    projectId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<string[]> {
+    const client = tx ?? dbClient;
+    const links = await client.testScenarioSpecLink.findMany({
+      where: linkedSpecWhere(scenarioId, projectId),
+      select: { specId: true },
+    });
+
+    return links.map(({ specId }) => specId);
+  },
+
+  async delete(
+    testScenarioId: string,
+    specId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<number> {
+    const client = tx ?? dbClient;
+    const result = await client.testScenarioSpecLink.deleteMany({
+      where: { testScenarioId, specId },
+    });
+
+    return result.count;
+  },
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -20,6 +20,7 @@ import ctrf from "@/routes/ctrf";
 import upload from "@/routes/upload";
 import analysisExport from "@/routes/analysis-export";
 import reports from "@/routes/reports";
+import testScenarios from "@/routes/test-scenarios";
 import mcp from "@/mcp/server";
 
 const router = Router();
@@ -46,6 +47,7 @@ router.use(projects);
 router.use(ctrf);
 router.use(upload);
 router.use(reports);
+router.use(testScenarios);
 router.use(mcp);
 
 export default router;

--- a/src/routes/test-scenarios.ts
+++ b/src/routes/test-scenarios.ts
@@ -17,6 +17,31 @@ router.get(
   authMiddleware,
   testScenarioController.list,
 );
+router.post(
+  "/v2/test-scenarios/:scenarioId/spec-links",
+  authMiddleware,
+  testScenarioController.addSpecLink,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/spec-links",
+  authMiddleware,
+  testScenarioController.listSpecLinks,
+);
+router.delete(
+  "/v2/test-scenarios/:scenarioId/spec-links/:specId",
+  authMiddleware,
+  testScenarioController.removeSpecLink,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/results",
+  authMiddleware,
+  testScenarioController.getResults,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId/issues",
+  authMiddleware,
+  testScenarioController.getIssues,
+);
 router.get(
   "/v2/test-scenarios/:scenarioId",
   authMiddleware,

--- a/src/routes/test-scenarios.ts
+++ b/src/routes/test-scenarios.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { Router } from "express";
+import { testScenarioController } from "@/controllers/testScenarioController";
+import { authMiddleware } from "@/middleware/authMiddleware";
+
+const router = Router();
+
+router.post(
+  "/v2/test-scenarios",
+  authMiddleware,
+  testScenarioController.create,
+);
+router.get(
+  "/v2/test-scenarios",
+  authMiddleware,
+  testScenarioController.list,
+);
+router.get(
+  "/v2/test-scenarios/:scenarioId",
+  authMiddleware,
+  testScenarioController.getById,
+);
+router.delete(
+  "/v2/test-scenarios/:scenarioId",
+  authMiddleware,
+  testScenarioController.delete,
+);
+
+export default router;

--- a/src/routes/test-scenarios.ts
+++ b/src/routes/test-scenarios.ts
@@ -42,6 +42,11 @@ router.get(
   authMiddleware,
   testScenarioController.getIssues,
 );
+router.patch(
+  "/v2/test-scenarios/:scenarioId",
+  authMiddleware,
+  testScenarioController.update,
+);
 router.get(
   "/v2/test-scenarios/:scenarioId",
   authMiddleware,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -28,3 +28,20 @@ export {
 } from "./testAnalysisSchemas";
 
 export { pdfExportSchema, type PdfExportInput } from "./reportExportSchemas";
+
+export {
+  testScenarioEvidenceParamsSchema,
+  testScenarioEvidenceQuerySchema,
+  testScenarioSpecLinkBodySchema,
+  testScenarioSpecLinkDeleteParamsSchema,
+  testScenarioSpecLinkListQuerySchema,
+  testScenarioSpecLinkParamsSchema,
+  testScenarioSpecLinkQuerySchema,
+  type TestScenarioEvidenceParams,
+  type TestScenarioEvidenceQuery,
+  type TestScenarioSpecLinkBody,
+  type TestScenarioSpecLinkDeleteParams,
+  type TestScenarioSpecLinkListQuery,
+  type TestScenarioSpecLinkParams,
+  type TestScenarioSpecLinkQuery,
+} from "./testScenarioIntegrationSchemas";

--- a/src/schemas/testScenarioIntegrationSchemas.ts
+++ b/src/schemas/testScenarioIntegrationSchemas.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from "zod";
+
+const uuidSchema = z.string().uuid("Must be a valid UUID");
+
+const positiveIntegerQuerySchema = (defaultValue: number, maximum?: number) => {
+  const schema = z.coerce
+    .number()
+    .int("Must be an integer")
+    .positive("Must be greater than zero");
+
+  return (maximum === undefined ? schema : schema.max(maximum)).default(
+    defaultValue,
+  );
+};
+
+export const testScenarioSpecLinkParamsSchema = z.object({
+  scenarioId: uuidSchema,
+});
+
+export const testScenarioSpecLinkDeleteParamsSchema = z.object({
+  scenarioId: uuidSchema,
+  specId: uuidSchema,
+});
+
+export const testScenarioSpecLinkQuerySchema = z.object({
+  projectId: uuidSchema,
+});
+
+export const testScenarioSpecLinkListQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export const testScenarioSpecLinkBodySchema = z.object({
+  specId: uuidSchema,
+});
+
+export const testScenarioEvidenceParamsSchema = testScenarioSpecLinkParamsSchema;
+
+export const testScenarioEvidenceQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export type TestScenarioSpecLinkParams = z.infer<
+  typeof testScenarioSpecLinkParamsSchema
+>;
+export type TestScenarioSpecLinkDeleteParams = z.infer<
+  typeof testScenarioSpecLinkDeleteParamsSchema
+>;
+export type TestScenarioSpecLinkQuery = z.infer<
+  typeof testScenarioSpecLinkQuerySchema
+>;
+export type TestScenarioSpecLinkListQuery = z.infer<
+  typeof testScenarioSpecLinkListQuerySchema
+>;
+export type TestScenarioSpecLinkBody = z.infer<
+  typeof testScenarioSpecLinkBodySchema
+>;
+export type TestScenarioEvidenceParams = z.infer<
+  typeof testScenarioEvidenceParamsSchema
+>;
+export type TestScenarioEvidenceQuery = z.infer<
+  typeof testScenarioEvidenceQuerySchema
+>;

--- a/src/schemas/testScenarioSchemas.ts
+++ b/src/schemas/testScenarioSchemas.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from "zod";
+
+const uuidSchema = z.string().uuid("Must be a valid UUID");
+
+export const createTestScenarioSchema = z
+  .object({
+    projectId: uuidSchema,
+    title: z.string().trim().min(1, "Title is required"),
+    contentMd: z.string().min(1, "contentMd is required"),
+  });
+
+export const testScenarioProjectQuerySchema = z.object({
+  projectId: uuidSchema,
+});
+
+export const testScenarioIdParamsSchema = z.object({
+  scenarioId: uuidSchema,
+});
+
+const positiveIntegerQuerySchema = (defaultValue: number, maximum?: number) => {
+  const schema = z.coerce
+    .number()
+    .int("Must be an integer")
+    .positive("Must be greater than zero");
+
+  return (maximum === undefined ? schema : schema.max(maximum)).default(
+    defaultValue,
+  );
+};
+
+export const testScenarioListQuerySchema = z.object({
+  projectId: uuidSchema,
+  page: positiveIntegerQuerySchema(1),
+  limit: positiveIntegerQuerySchema(30, 100),
+});
+
+export type CreateTestScenarioInput = z.infer<typeof createTestScenarioSchema>;
+export type TestScenarioProjectQuery = z.infer<
+  typeof testScenarioProjectQuerySchema
+>;
+export type TestScenarioIdParams = z.infer<typeof testScenarioIdParamsSchema>;
+export type TestScenarioListQuery = z.infer<
+  typeof testScenarioListQuerySchema
+>;

--- a/src/schemas/testScenarioSchemas.ts
+++ b/src/schemas/testScenarioSchemas.ts
@@ -12,6 +12,25 @@ export const createTestScenarioSchema = z
     contentMd: z.string().min(1, "contentMd is required"),
   });
 
+const updateTestScenarioTitleSchema = z
+  .object({
+    title: z.string().trim().min(1, "Title is required"),
+    contentMd: z.string().min(1, "contentMd is required").optional(),
+  })
+  .strict();
+
+const updateTestScenarioContentSchema = z
+  .object({
+    title: z.string().trim().min(1, "Title is required").optional(),
+    contentMd: z.string().min(1, "contentMd is required"),
+  })
+  .strict();
+
+export const updateTestScenarioSchema = z.union([
+  updateTestScenarioTitleSchema,
+  updateTestScenarioContentSchema,
+]);
+
 export const testScenarioProjectQuerySchema = z.object({
   projectId: uuidSchema,
 });
@@ -38,6 +57,7 @@ export const testScenarioListQuerySchema = z.object({
 });
 
 export type CreateTestScenarioInput = z.infer<typeof createTestScenarioSchema>;
+export type UpdateTestScenarioInput = z.infer<typeof updateTestScenarioSchema>;
 export type TestScenarioProjectQuery = z.infer<
   typeof testScenarioProjectQuerySchema
 >;

--- a/src/services/issueService.ts
+++ b/src/services/issueService.ts
@@ -170,6 +170,40 @@ export const issueService = {
     return serializeIssue(issueRecords);
   },
 
+  async getObservedIssuesBySpecRecordIds(params: {
+    projectId: string;
+    specRecordIds: string[];
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    issues: SerializedIssue[];
+    total: number;
+  }> {
+    if (!params.projectId) {
+      throw new Error("Project ID is required");
+    }
+
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 30;
+    const [issues, total] = await Promise.all([
+      issueModel.findObservedBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+        page,
+        limit,
+      ),
+      issueModel.countObservedBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+      ),
+    ]);
+
+    return {
+      issues: issues.map(serializeIssue),
+      total,
+    };
+  },
+
   async createIssue(issueParams: CreateIssueParams): Promise<PrismaIssue> {
     if (!issueParams?.name) {
       throw new Error("Unable to create issue without name");

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -140,6 +140,37 @@ export const resultService = {
     return normalizeResultPayload(resultRecord);
   },
 
+  async getResultsBySpecRecordIds(params: {
+    projectId: string;
+    specRecordIds: string[];
+    page?: number;
+    limit?: number;
+  }): Promise<{
+    results: StructuredResultWithRelations[];
+    total: number;
+  }> {
+    if (!params.projectId) {
+      throw new Error("Project ID is required");
+    }
+
+    const page = params.page ?? 1;
+    const limit = params.limit ?? 30;
+    const [results, total] = await Promise.all([
+      resultModel.findManyBySpecRecordIds(
+        params.specRecordIds,
+        params.projectId,
+        page,
+        limit,
+      ),
+      resultModel.countBySpecRecordIds(params.specRecordIds, params.projectId),
+    ]);
+
+    return {
+      results: results.map(normalizeResultPayload),
+      total,
+    };
+  },
+
   async getResultsStats(params: GetResultsStatsParams): Promise<ResultsStats> {
     const { projectId, dates } = params;
 

--- a/src/services/testScenarioIntegrationService.ts
+++ b/src/services/testScenarioIntegrationService.ts
@@ -1,0 +1,261 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { Prisma } from "@prisma/client";
+import { issueService } from "@/services/issueService";
+import { resultService } from "@/services/resultService";
+import { testScenarioSpecLinkModel } from "@/models/testScenarioSpecLinkModel";
+import { specModel } from "@/models/specModel";
+import { testScenarioModel } from "@/models/testScenarioModel";
+import { normalizeSpecPayload } from "@/lib/jsonPayloads";
+import {
+  TestScenarioNotFoundError,
+} from "@/types/testScenarios";
+import {
+  TestScenarioIntegrationValidationError,
+  TestScenarioSpecLinkConflictError,
+  TestScenarioSpecLinkNotFoundError,
+  type AddTestScenarioSpecLinkParams,
+  type ListTestScenarioSpecLinksParams,
+  type TestScenarioEvidenceParams,
+  type TestScenarioIssuesResponse,
+  type TestScenarioResultsResponse,
+  type TestScenarioSpecLinkResponse,
+  type TestScenarioSpecLinksResponse,
+} from "@/types/testScenarioIntegration";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+function validateContext(scenarioId: string, projectId: string): void {
+  if (!scenarioId) {
+    throw new TestScenarioIntegrationValidationError(
+      "Scenario ID is required",
+    );
+  }
+
+  if (!projectId) {
+    throw new TestScenarioIntegrationValidationError("Project ID is required");
+  }
+}
+
+function resolvePagination(
+  page: number | undefined,
+  limit: number | undefined,
+): { page: number; limit: number } {
+  const resolvedPage = page ?? DEFAULT_PAGE;
+  const resolvedLimit = limit ?? DEFAULT_LIMIT;
+
+  if (!Number.isInteger(resolvedPage) || resolvedPage < 1) {
+    throw new TestScenarioIntegrationValidationError(
+      "page must be a positive integer",
+    );
+  }
+
+  if (
+    !Number.isInteger(resolvedLimit) ||
+    resolvedLimit < 1 ||
+    resolvedLimit > MAX_LIMIT
+  ) {
+    throw new TestScenarioIntegrationValidationError(
+      `limit must be a positive integer no greater than ${MAX_LIMIT}`,
+    );
+  }
+
+  return { page: resolvedPage, limit: resolvedLimit };
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code === "P2002";
+  }
+
+  if (typeof error === "object" && error !== null && "code" in error) {
+    return (error as { code?: unknown }).code === "P2002";
+  }
+
+  return false;
+}
+
+async function requireScenario(
+  scenarioId: string,
+  projectId: string,
+): Promise<void> {
+  validateContext(scenarioId, projectId);
+
+  const scenario = await testScenarioModel.findById(scenarioId, projectId);
+  if (!scenario) {
+    throw new TestScenarioNotFoundError(
+      `Test scenario with id '${scenarioId}' not found`,
+    );
+  }
+}
+
+async function resolveLinkedSpecIds(
+  scenarioId: string,
+  projectId: string,
+): Promise<{ specIds: string[]; count: number }> {
+  const [specIds, count] = await Promise.all([
+    testScenarioSpecLinkModel.findLinkedSpecIds(scenarioId, projectId),
+    testScenarioSpecLinkModel.countLinkedSpecs(scenarioId, projectId),
+  ]);
+
+  return {
+    specIds: [...new Set(specIds)],
+    count,
+  };
+}
+
+export const testScenarioIntegrationService = {
+  async addSpecLink(
+    params: AddTestScenarioSpecLinkParams,
+  ): Promise<TestScenarioSpecLinkResponse> {
+    validateContext(params.scenarioId, params.projectId);
+    if (!params.specId) {
+      throw new TestScenarioIntegrationValidationError("Spec ID is required");
+    }
+
+    const [scenario, spec] = await Promise.all([
+      testScenarioModel.findById(params.scenarioId, params.projectId),
+      specModel.findById(params.specId, params.projectId),
+    ]);
+    if (!scenario || !spec) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario or Spec not found in the requested project",
+      );
+    }
+
+    try {
+      await testScenarioSpecLinkModel.create({
+        testScenarioId: params.scenarioId,
+        specId: params.specId,
+      });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new TestScenarioSpecLinkConflictError(
+          "The Test Scenario is already linked to this Spec",
+        );
+      }
+      throw error;
+    }
+
+    return {
+      scenarioId: params.scenarioId,
+      specId: params.specId,
+    };
+  },
+
+  async listSpecLinks(
+    params: ListTestScenarioSpecLinksParams,
+  ): Promise<TestScenarioSpecLinksResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+
+    const [links, total] = await Promise.all([
+      testScenarioSpecLinkModel.findLinkedSpecs(
+        params.scenarioId,
+        params.projectId,
+        page,
+        limit,
+      ),
+      testScenarioSpecLinkModel.countLinkedSpecs(
+        params.scenarioId,
+        params.projectId,
+      ),
+    ]);
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      specs: links.map(({ spec }) => normalizeSpecPayload(spec)),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async removeSpecLink(params: AddTestScenarioSpecLinkParams): Promise<void> {
+    validateContext(params.scenarioId, params.projectId);
+    if (!params.specId) {
+      throw new TestScenarioIntegrationValidationError("Spec ID is required");
+    }
+
+    const [scenario, spec] = await Promise.all([
+      testScenarioModel.findById(params.scenarioId, params.projectId),
+      specModel.findById(params.specId, params.projectId),
+    ]);
+    if (!scenario || !spec) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario or Spec not found in the requested project",
+      );
+    }
+
+    const deletedCount = await testScenarioSpecLinkModel.delete(
+      params.scenarioId,
+      params.specId,
+    );
+    if (deletedCount === 0) {
+      throw new TestScenarioSpecLinkNotFoundError(
+        "Test scenario and Spec link not found",
+      );
+    }
+  },
+
+  async getResults(
+    params: TestScenarioEvidenceParams,
+  ): Promise<TestScenarioResultsResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+    const { specIds, count: linkedSpecCount } = await resolveLinkedSpecIds(
+      params.scenarioId,
+      params.projectId,
+    );
+    const evidence = await resultService.getResultsBySpecRecordIds({
+      projectId: params.projectId,
+      specRecordIds: specIds,
+      page,
+      limit,
+    });
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      linkedSpecCount,
+      results: evidence.results,
+      total: evidence.total,
+      page,
+      limit,
+      totalPages: Math.ceil(evidence.total / limit),
+    };
+  },
+
+  async getIssues(
+    params: TestScenarioEvidenceParams,
+  ): Promise<TestScenarioIssuesResponse> {
+    const { page, limit } = resolvePagination(params.page, params.limit);
+    await requireScenario(params.scenarioId, params.projectId);
+    const { specIds, count: linkedSpecCount } = await resolveLinkedSpecIds(
+      params.scenarioId,
+      params.projectId,
+    );
+    const evidence = await issueService.getObservedIssuesBySpecRecordIds({
+      projectId: params.projectId,
+      specRecordIds: specIds,
+      page,
+      limit,
+    });
+
+    return {
+      scenarioId: params.scenarioId,
+      projectId: params.projectId,
+      linkedSpecCount,
+      issues: evidence.issues,
+      total: evidence.total,
+      page,
+      limit,
+      totalPages: Math.ceil(evidence.total / limit),
+    };
+  },
+};

--- a/src/services/testScenarioService.ts
+++ b/src/services/testScenarioService.ts
@@ -10,6 +10,7 @@ import {
   type ListTestScenariosParams,
   type TestScenarioListResponse,
   type TestScenarioResponse,
+  type UpdateTestScenarioParams,
 } from "@/types/testScenarios";
 
 const DEFAULT_PAGE = 1;
@@ -93,6 +94,57 @@ export const testScenarioService = {
     if (!scenario) {
       throw new TestScenarioNotFoundError(
         `Test scenario with id '${scenarioId}' not found`,
+      );
+    }
+
+    return scenario;
+  },
+
+  async updateScenario(
+    params: UpdateTestScenarioParams,
+  ): Promise<TestScenarioResponse> {
+    if (!params.scenarioId) {
+      throw new TestScenarioValidationError("Scenario ID is required");
+    }
+
+    if (!params.projectId) {
+      throw new TestScenarioValidationError("Project ID is required");
+    }
+
+    if (params.title === undefined && params.contentMd === undefined) {
+      throw new TestScenarioValidationError(
+        "At least one of title or contentMd is required",
+      );
+    }
+
+    if (
+      params.title !== undefined &&
+      (typeof params.title !== "string" || !params.title.trim())
+    ) {
+      throw new TestScenarioValidationError("Title is required");
+    }
+
+    if (
+      params.contentMd !== undefined &&
+      (typeof params.contentMd !== "string" || params.contentMd.length === 0)
+    ) {
+      throw new TestScenarioValidationError("contentMd is required");
+    }
+
+    const scenario = await testScenarioModel.update(
+      params.scenarioId,
+      params.projectId,
+      {
+        ...(params.title !== undefined ? { title: params.title.trim() } : {}),
+        ...(params.contentMd !== undefined
+          ? { contentMd: params.contentMd }
+          : {}),
+      },
+    );
+
+    if (!scenario) {
+      throw new TestScenarioNotFoundError(
+        `Test scenario with id '${params.scenarioId}' not found`,
       );
     }
 

--- a/src/services/testScenarioService.ts
+++ b/src/services/testScenarioService.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { projectModel } from "@/models/projectModel";
+import { testScenarioModel } from "@/models/testScenarioModel";
+import {
+  TestScenarioNotFoundError,
+  TestScenarioValidationError,
+  type CreateTestScenarioParams,
+  type ListTestScenariosParams,
+  type TestScenarioListResponse,
+  type TestScenarioResponse,
+} from "@/types/testScenarios";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 30;
+const MAX_LIMIT = 100;
+
+function validatePagination(page: number, limit: number): void {
+  if (!Number.isInteger(page) || page < 1) {
+    throw new TestScenarioValidationError(
+      "page must be a positive integer",
+    );
+  }
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT) {
+    throw new TestScenarioValidationError(
+      `limit must be a positive integer no greater than ${MAX_LIMIT}`,
+    );
+  }
+}
+
+export const testScenarioService = {
+  async createScenario(
+    params: CreateTestScenarioParams,
+  ): Promise<TestScenarioResponse> {
+    if (!params.title.trim()) {
+      throw new TestScenarioValidationError("Title is required");
+    }
+
+    if (params.contentMd.length === 0) {
+      throw new TestScenarioValidationError("contentMd is required");
+    }
+
+    if (!(await projectModel.exists(params.projectId))) {
+      throw new TestScenarioNotFoundError(
+        `Project with id '${params.projectId}' not found`,
+      );
+    }
+
+    return await testScenarioModel.create({
+      projectId: params.projectId,
+      title: params.title.trim(),
+      contentMd: params.contentMd,
+      createdById: params.createdById,
+    });
+  },
+
+  async listScenarios(
+    params: ListTestScenariosParams,
+  ): Promise<TestScenarioListResponse> {
+    const page = params.page ?? DEFAULT_PAGE;
+    const limit = params.limit ?? DEFAULT_LIMIT;
+    validatePagination(page, limit);
+
+    const [scenarios, total] = await Promise.all([
+      testScenarioModel.findMany(params.projectId, page, limit),
+      testScenarioModel.count(params.projectId),
+    ]);
+
+    return {
+      scenarios,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  },
+
+  async getScenarioById(
+    scenarioId: string,
+    projectId: string,
+  ): Promise<TestScenarioResponse> {
+    if (!scenarioId) {
+      throw new TestScenarioValidationError("Scenario ID is required");
+    }
+
+    if (!projectId) {
+      throw new TestScenarioValidationError("Project ID is required");
+    }
+
+    const scenario = await testScenarioModel.findById(scenarioId, projectId);
+    if (!scenario) {
+      throw new TestScenarioNotFoundError(
+        `Test scenario with id '${scenarioId}' not found`,
+      );
+    }
+
+    return scenario;
+  },
+
+  async deleteScenario(scenarioId: string, projectId: string): Promise<void> {
+    if (!scenarioId) {
+      throw new TestScenarioValidationError("Scenario ID is required");
+    }
+
+    if (!projectId) {
+      throw new TestScenarioValidationError("Project ID is required");
+    }
+
+    const deletedCount = await testScenarioModel.delete(scenarioId, projectId);
+    if (deletedCount === 0) {
+      throw new TestScenarioNotFoundError(
+        `Test scenario with id '${scenarioId}' not found`,
+      );
+    }
+  },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export * from "@/types/tests";
 export * from "@/types/ctrf";
 export * from "@/types/skills";
 export * from "@/types/testScenarios";
+export * from "@/types/testScenarioIntegration";
 
 // Express types extensions
 import type { Request } from "express";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "@/types/mcp";
 export * from "@/types/tests";
 export * from "@/types/ctrf";
 export * from "@/types/skills";
+export * from "@/types/testScenarios";
 
 // Express types extensions
 import type { Request } from "express";

--- a/src/types/testScenarioIntegration.ts
+++ b/src/types/testScenarioIntegration.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  SerializedIssue,
+  StructuredResultWithRelations,
+  StructuredSpec,
+} from "@/types/database";
+
+export interface AddTestScenarioSpecLinkParams {
+  scenarioId: string;
+  specId: string;
+  projectId: string;
+}
+
+export interface ListTestScenarioSpecLinksParams {
+  scenarioId: string;
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioEvidenceParams {
+  scenarioId: string;
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioSpecLinkResponse {
+  scenarioId: string;
+  specId: string;
+}
+
+export interface TestScenarioSpecLinksResponse {
+  scenarioId: string;
+  projectId: string;
+  specs: StructuredSpec[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface TestScenarioResultsResponse {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  results: StructuredResultWithRelations[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface TestScenarioIssuesResponse {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  issues: SerializedIssue[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class TestScenarioIntegrationValidationError extends Error {
+  readonly code = "TEST_SCENARIO_INTEGRATION_VALIDATION_ERROR" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioIntegrationValidationError";
+  }
+}
+
+export class TestScenarioSpecLinkNotFoundError extends Error {
+  readonly code = "TEST_SCENARIO_SPEC_LINK_NOT_FOUND" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioSpecLinkNotFoundError";
+  }
+}
+
+export class TestScenarioSpecLinkConflictError extends Error {
+  readonly code = "TEST_SCENARIO_SPEC_LINK_CONFLICT" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioSpecLinkConflictError";
+  }
+}

--- a/src/types/testScenarios.ts
+++ b/src/types/testScenarios.ts
@@ -20,6 +20,13 @@ export interface CreateTestScenarioParams {
   createdById: string;
 }
 
+export interface UpdateTestScenarioParams {
+  scenarioId: string;
+  projectId: string;
+  title?: string | undefined;
+  contentMd?: string | undefined;
+}
+
 export interface ListTestScenariosParams {
   projectId: string;
   page?: number | undefined;

--- a/src/types/testScenarios.ts
+++ b/src/types/testScenarios.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export interface TestScenarioResponse {
+  id: string;
+  projectId: string;
+  createdById: string;
+  title: string;
+  contentMd: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type TestScenarioRecord = TestScenarioResponse;
+
+export interface CreateTestScenarioParams {
+  projectId: string;
+  title: string;
+  contentMd: string;
+  createdById: string;
+}
+
+export interface ListTestScenariosParams {
+  projectId: string;
+  page?: number | undefined;
+  limit?: number | undefined;
+}
+
+export interface TestScenarioListResponse {
+  scenarios: TestScenarioResponse[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class TestScenarioValidationError extends Error {
+  readonly code = "TEST_SCENARIO_VALIDATION_ERROR" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioValidationError";
+  }
+}
+
+export class TestScenarioNotFoundError extends Error {
+  readonly code = "TEST_SCENARIO_NOT_FOUND" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TestScenarioNotFoundError";
+  }
+}


### PR DESCRIPTION
## Summary

- Add authenticated, project-scoped partial updates for Markdown test scenarios.
- Preserve omitted fields, raw Markdown content, immutable metadata, and linked execution evidence.
- Add strict Zod validation, OpenAPI documentation, and model-to-route regression coverage.

## Verification

- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` (438 tests passed)

## Dependency

- Stacked on #79.
- Closes #74.
