### PR TITLE
Add lightweight Test Scenario summaries

### DIFF
--- a/__tests__/controllers/testScenarioController.test.ts
+++ b/__tests__/controllers/testScenarioController.test.ts
@@ -7,11 +7,12 @@ import type { TestScenario } from "@prisma/client";
 import {
   executeController,
 } from "@/test-utils/httpMocks";
+import type { TestScenarioSummary } from "@/types/testScenarios";
 
 const createScenarioMock = jest.fn<() => Promise<TestScenario>>();
 const listScenariosMock = jest.fn<
   () => Promise<{
-    scenarios: TestScenario[];
+    scenarios: TestScenarioSummary[];
     total: number;
     page: number;
     limit: number;
@@ -45,6 +46,7 @@ const scenario: TestScenario = {
   createdById: "33333333-3333-3333-3333-333333333333",
   title: "Scenario",
   contentMd: "# Exact\n\n  Markdown ✓\n",
+  details: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -57,13 +59,27 @@ const authenticatedUser = {
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 } as const;
+const summary: TestScenarioSummary = {
+  id: scenario.id,
+  projectId: scenario.projectId,
+  createdById: scenario.createdById,
+  title: scenario.title,
+  details: scenario.details,
+  createdBy: {
+    id: scenario.createdById,
+    name: authenticatedUser.name,
+    email: authenticatedUser.email,
+  },
+  createdAt: scenario.createdAt,
+  updatedAt: scenario.updatedAt,
+};
 
 describe("testScenarioController", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     createScenarioMock.mockResolvedValue(scenario);
     listScenariosMock.mockResolvedValue({
-      scenarios: [scenario],
+      scenarios: [summary],
       total: 1,
       page: 1,
       limit: 30,
@@ -82,7 +98,7 @@ describe("testScenarioController", () => {
         projectId,
         title: "  Scenario  ",
         contentMd: scenario.contentMd,
-        createdById: "99999999-9999-9999-9999-999999999999",
+        details: "  Scenario details  ",
       },
     });
 
@@ -93,7 +109,24 @@ describe("testScenarioController", () => {
       title: "Scenario",
       contentMd: scenario.contentMd,
       createdById: authenticatedUser.id,
+      details: "Scenario details",
     });
+  });
+
+  it("rejects unsupported creator input", async () => {
+    const response = await executeController(testScenarioController.create, {
+      method: "POST",
+      user: authenticatedUser,
+      body: {
+        projectId,
+        title: "Scenario",
+        contentMd: "content",
+        createdById: "99999999-9999-9999-9999-999999999999",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(createScenarioMock).not.toHaveBeenCalled();
   });
 
   it("requires an authenticated user before creating a scenario", async () => {
@@ -145,7 +178,7 @@ describe("testScenarioController", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual(expect.objectContaining({
-      scenarios: [scenario],
+      scenarios: [summary],
       page: 1,
       limit: 30,
     }));
@@ -200,6 +233,7 @@ describe("testScenarioController", () => {
       ...scenario,
       title: "Updated title",
       contentMd: "# Updated",
+      details: "Updated details",
       updatedAt: new Date("2026-01-02T00:00:00.000Z"),
     };
     updateScenarioMock.mockResolvedValue(updatedScenario);
@@ -208,7 +242,11 @@ describe("testScenarioController", () => {
       method: "PATCH",
       params: { scenarioId },
       query: { projectId },
-      body: { title: " Updated title ", contentMd: "# Updated" },
+      body: {
+        title: " Updated title ",
+        contentMd: "# Updated",
+        details: " Updated details ",
+      },
     });
 
     expect(response.statusCode).toBe(200);
@@ -218,6 +256,7 @@ describe("testScenarioController", () => {
       projectId,
       title: "Updated title",
       contentMd: "# Updated",
+      details: "Updated details",
     });
   });
 
@@ -232,6 +271,22 @@ describe("testScenarioController", () => {
     expect(response.statusCode).toBe(400);
     expect(response.body).toEqual(expect.objectContaining({ error: expect.any(String) }));
     expect(updateScenarioMock).not.toHaveBeenCalled();
+  });
+
+  it("passes an explicit null details update through to the service", async () => {
+    const response = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId },
+      query: { projectId },
+      body: { details: null },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(updateScenarioMock).toHaveBeenCalledWith({
+      scenarioId,
+      projectId,
+      details: null,
+    });
   });
 
   it("maps update not-found and unexpected errors", async () => {

--- a/__tests__/lib/openapi/testScenarios.test.ts
+++ b/__tests__/lib/openapi/testScenarios.test.ts
@@ -44,6 +44,8 @@ describe("test-scenario OpenAPI contract", () => {
     const schemas = spec.components?.schemas ?? {};
 
     expect(schemas.TestScenario).toBeDefined();
+    expect(schemas.TestScenarioSummary).toBeDefined();
+    expect(schemas.TestScenarioCreatorSummary).toBeDefined();
     expect(schemas.CreateTestScenarioRequest).toBeDefined();
     expect(schemas.UpdateTestScenarioRequest).toBeDefined();
     expect(schemas.TestScenarioListResponse).toBeDefined();
@@ -54,11 +56,18 @@ describe("test-scenario OpenAPI contract", () => {
       properties?: Record<string, unknown>;
     };
     const createSchema = schemas.CreateTestScenarioRequest as {
+      additionalProperties?: boolean;
       properties?: Record<string, unknown>;
     };
     expect(scenarioSchema.required).toContain("createdById");
+    expect(scenarioSchema.required).toContain("details");
     expect(scenarioSchema.properties?.createdById).toBeDefined();
+    expect(scenarioSchema.properties?.details).toEqual({
+      type: ["string", "null"],
+    });
     expect(createSchema.properties?.createdById).toBeUndefined();
+    expect(createSchema.properties?.details).toBeDefined();
+    expect(createSchema.additionalProperties).toBe(false);
 
     const listResponse = schemas.TestScenarioListResponse as {
       properties?: Record<string, unknown>;
@@ -69,6 +78,51 @@ describe("test-scenario OpenAPI contract", () => {
       "page",
       "limit",
       "totalPages",
+    ]);
+    expect(listResponse.properties?.scenarios).toEqual({
+      items: { $ref: "#/components/schemas/TestScenarioSummary" },
+      type: "array",
+    });
+
+    const summarySchema = schemas.TestScenarioSummary as {
+      additionalProperties?: boolean;
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+    expect(summarySchema.additionalProperties).toBe(false);
+    expect(summarySchema.required).toEqual([
+      "id",
+      "projectId",
+      "createdById",
+      "title",
+      "details",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+    ]);
+    expect(Object.keys(summarySchema.properties ?? {})).toEqual([
+      "id",
+      "projectId",
+      "createdById",
+      "title",
+      "details",
+      "createdBy",
+      "createdAt",
+      "updatedAt",
+    ]);
+    expect(summarySchema.properties?.contentMd).toBeUndefined();
+
+    const creatorSchema = schemas.TestScenarioCreatorSummary as {
+      additionalProperties?: boolean;
+      required?: string[];
+      properties?: Record<string, unknown>;
+    };
+    expect(creatorSchema.additionalProperties).toBe(false);
+    expect(creatorSchema.required).toEqual(["id", "name", "email"]);
+    expect(Object.keys(creatorSchema.properties ?? {})).toEqual([
+      "id",
+      "name",
+      "email",
     ]);
 
     const listQuery = schemas.TestScenarioListQuery as {
@@ -95,16 +149,19 @@ describe("test-scenario OpenAPI contract", () => {
     };
     const alternatives = updateSchema.oneOf ?? updateSchema.anyOf;
 
-    expect(alternatives).toHaveLength(2);
+    expect(alternatives).toHaveLength(3);
     expect(alternatives?.[0]?.additionalProperties).toBe(false);
     expect(alternatives?.[1]?.additionalProperties).toBe(false);
+    expect(alternatives?.[2]?.additionalProperties).toBe(false);
     expect(alternatives?.map((alternative) => alternative.required)).toEqual([
       ["title"],
       ["contentMd"],
+      ["details"],
     ]);
     for (const alternative of alternatives ?? []) {
       expect(Object.keys(alternative.properties ?? {}).sort()).toEqual([
         "contentMd",
+        "details",
         "title",
       ]);
       expect(alternative.properties?.projectId).toBeUndefined();

--- a/__tests__/mcp/mcpTestScenarioHandler.test.ts
+++ b/__tests__/mcp/mcpTestScenarioHandler.test.ts
@@ -53,7 +53,7 @@ const getIssuesMock =
 
 jest.mock("@/services/testScenarioService", () => ({
   testScenarioService: {
-    listScenarioSummaries: listSummariesMock,
+    listScenarios: listSummariesMock,
     getScenarioById: getScenarioMock,
     updateScenario: updateScenarioMock,
     deleteScenario: deleteScenarioMock,
@@ -76,6 +76,7 @@ const scenario: TestScenarioResponse = {
   createdById: "33333333-3333-3333-3333-333333333333",
   title: "Login",
   contentMd: "  # Login\n\n  exact ✓\n",
+  details: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -117,7 +118,7 @@ describe("mcpTestScenarioHandler", () => {
     getIssuesMock.mockResolvedValue(issueEvidence);
   });
 
-  it("delegates list requests to the compact summary service", async () => {
+  it("delegates list requests to the shared summary service", async () => {
     const params: TestScenarioMcpListParams = {
       projectId,
       page: 2,
@@ -178,13 +179,18 @@ describe("mcpTestScenarioHandler", () => {
   it.each([
     [{ title: "  Updated title  " }, "title-only"],
     [{ contentMd: "\n  # Exact Markdown ✓\n" }, "Markdown-only"],
+    [{ details: "  Updated details  " }, "details-only"],
+    [{ details: null }, "clear-details"],
     [
       { title: "  Combined  ", contentMd: "# Combined\n\n  exact\n" },
       "combined",
     ],
   ])(
     "delegates %s updates without rewriting authored fields",
-    async (fields: { title?: string; contentMd?: string }, _label: string) => {
+    async (
+      fields: { title?: string; contentMd?: string; details?: string | null },
+      _label: string,
+    ) => {
       const params = {
         scenarioId,
         projectId,

--- a/__tests__/mcp/testScenarioMcpWorkflow.test.ts
+++ b/__tests__/mcp/testScenarioMcpWorkflow.test.ts
@@ -66,7 +66,7 @@ const scenarioUpdateMock =
     (
       scenarioId: string,
       projectId: string,
-      data: { title?: string; contentMd?: string },
+      data: { title?: string; contentMd?: string; details?: string | null },
     ) => Promise<TestScenario | null>
   >();
 const scenarioDeleteMock =
@@ -138,6 +138,7 @@ const scenarioA: TestScenario = {
   createdById: "88888888-8888-8888-8888-888888888888",
   title: "Login",
   contentMd: "  # Login\n\n  exact Markdown ✓\n",
+  details: "Existing details",
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -253,7 +254,20 @@ describe("Test Scenario MCP workflow", () => {
               right.id.localeCompare(left.id),
           )
           .slice((page - 1) * limit, page * limit)
-          .map(({ contentMd: _contentMd, ...summary }) => summary),
+          .map((scenario) => ({
+            id: scenario.id,
+            projectId: scenario.projectId,
+            createdById: scenario.createdById,
+            title: scenario.title,
+            details: scenario.details,
+            createdBy: {
+              id: scenario.createdById,
+              name: "Scenario Creator",
+              email: "creator@example.com",
+            },
+            createdAt: scenario.createdAt,
+            updatedAt: scenario.updatedAt,
+          })),
     );
     scenarioCountMock.mockImplementation(
       async (projectId) =>
@@ -398,6 +412,36 @@ describe("Test Scenario MCP workflow", () => {
     expect(
       list.scenarios.every((scenario) => !Object.hasOwn(scenario, "contentMd")),
     ).toBe(true);
+    expect(Object.keys(list.scenarios[0] ?? {}).sort()).toEqual([
+      "createdAt",
+      "createdBy",
+      "createdById",
+      "details",
+      "id",
+      "projectId",
+      "title",
+      "updatedAt",
+    ]);
+    expect(list.scenarios[0]?.createdBy).toEqual({
+      id: scenarioA.createdById,
+      name: "Scenario Creator",
+      email: "creator@example.com",
+    });
+    expect(Object.keys(list.scenarios[0] ?? {}).sort()).toEqual([
+      "createdAt",
+      "createdBy",
+      "createdById",
+      "details",
+      "id",
+      "projectId",
+      "title",
+      "updatedAt",
+    ]);
+    expect(list.scenarios[0]?.createdBy).toEqual({
+      id: scenarioA.createdById,
+      name: "Scenario Creator",
+      email: "creator@example.com",
+    });
   });
 
   it("returns raw Markdown and linked deduplicated evidence with independent pages", async () => {
@@ -426,6 +470,7 @@ describe("Test Scenario MCP workflow", () => {
     };
 
     expect(detail.scenario.contentMd).toBe(scenarioA.contentMd);
+    expect(detail.scenario.details).toBe(scenarioA.details);
     expect(detail.resultEvidence).toMatchObject({
       linkedSpecCount: 2,
       page: 2,
@@ -505,6 +550,25 @@ describe("Test Scenario MCP workflow", () => {
       title: "Combined title",
       contentMd: "# Combined\n",
     });
+
+    const detailsUpdate = await invokeTool(updateTestScenario[3], {
+      scenarioId: scenarioAId,
+      projectId: projectA,
+      details: "  Updated details  ",
+    });
+    expect((detailsUpdate.data as TestScenario).details).toBe(
+      "Updated details",
+    );
+    expect((detailsUpdate.data as TestScenario).contentMd).toBe(
+      "# Combined\n",
+    );
+
+    const clearDetails = await invokeTool(updateTestScenario[3], {
+      scenarioId: scenarioAId,
+      projectId: projectA,
+      details: null,
+    });
+    expect((clearDetails.data as TestScenario).details).toBeNull();
 
     const beforeInvalid = {
       ...scenarios.find((scenario) => scenario.id === scenarioAId),

--- a/__tests__/mcp/testScenarioSchemas.test.ts
+++ b/__tests__/mcp/testScenarioSchemas.test.ts
@@ -102,6 +102,20 @@ describe("Test Scenario MCP schemas", () => {
       updateTestScenarioSchema.safeParse({
         scenarioId,
         projectId,
+        details: "  Human-readable details  ",
+      }).success,
+    ).toBe(true);
+    expect(
+      updateTestScenarioSchema.safeParse({
+        scenarioId,
+        projectId,
+        details: null,
+      }).success,
+    ).toBe(true);
+    expect(
+      updateTestScenarioSchema.safeParse({
+        scenarioId,
+        projectId,
         title: "Updated title",
         contentMd: "# Exact Markdown\n",
       }).success,
@@ -112,6 +126,20 @@ describe("Test Scenario MCP schemas", () => {
         scenarioId,
         projectId,
         createdById: "33333333-3333-3333-3333-333333333333",
+      }).success,
+    ).toBe(false);
+    expect(
+      updateTestScenarioSchema.safeParse({
+        scenarioId,
+        projectId,
+        details: "   ",
+      }).success,
+    ).toBe(false);
+    expect(
+      updateTestScenarioSchema.safeParse({
+        scenarioId,
+        projectId,
+        details: 123,
       }).success,
     ).toBe(false);
   });

--- a/__tests__/mcp/testScenarioTools.test.ts
+++ b/__tests__/mcp/testScenarioTools.test.ts
@@ -40,6 +40,7 @@ const scenario: TestScenarioResponse = {
   createdById: "33333333-3333-3333-3333-333333333333",
   title: "Login",
   contentMd: "# Login\n\n  exact ✓\n",
+  details: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -99,7 +100,7 @@ describe("Test Scenario MCP tools", () => {
     const updateResponse = (await updateTestScenario[3]({
       scenarioId,
       projectId,
-      contentMd: "# Exact",
+      details: "Updated details",
     })) as MCPToolResponse;
     const deleteResponse = (await deleteTestScenario[3]({
       scenarioId,

--- a/__tests__/models/testScenarioModel.test.ts
+++ b/__tests__/models/testScenarioModel.test.ts
@@ -6,13 +6,13 @@ import { jest } from "@jest/globals";
 import type { Prisma, TestScenario } from "@prisma/client";
 
 const createMock = jest.fn<() => Promise<TestScenario>>();
-const findManyMock = jest.fn<(args: unknown) => Promise<TestScenario[]>>();
+const findManyMock = jest.fn<(args: unknown) => Promise<unknown[]>>();
 const countMock = jest.fn<() => Promise<number>>();
 const findFirstMock = jest.fn<() => Promise<TestScenario | null>>();
 const updateMock = jest.fn<
   (args: {
     where: { id: string };
-    data: { title?: string; contentMd?: string };
+    data: { title?: string; contentMd?: string; details?: string | null };
   }) => Promise<TestScenario>
 >();
 const deleteManyMock = jest.fn<() => Promise<{ count: number }>>();
@@ -44,6 +44,7 @@ const scenario: TestScenario = {
   createdById: "33333333-3333-3333-3333-333333333333",
   title: "Login",
   contentMd: "# Login",
+  details: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -85,33 +86,7 @@ describe("testScenarioModel", () => {
     });
   });
 
-  it("lists by project with deterministic ordering and offset pagination", async () => {
-    await testScenarioModel.findMany(scenario.projectId, 3, 10);
-
-    expect(findManyMock).toHaveBeenCalledWith({
-      where: { projectId: scenario.projectId },
-      skip: 20,
-      take: 10,
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-    });
-  });
-
-  it("uses the same project predicate for list and count", async () => {
-    await testScenarioModel.findMany(scenario.projectId);
-    await testScenarioModel.count(scenario.projectId);
-
-    expect(findManyMock).toHaveBeenCalledWith({
-      where: { projectId: scenario.projectId },
-      skip: 0,
-      take: 30,
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-    });
-    expect(countMock).toHaveBeenCalledWith({
-      where: { projectId: scenario.projectId },
-    });
-  });
-
-  it("lists compact summaries without selecting Markdown", async () => {
+  it("lists exact summaries without selecting Markdown or sensitive creator fields", async () => {
     await testScenarioModel.findManySummaries(scenario.projectId, 2, 10);
 
     expect(findManyMock).toHaveBeenCalledWith({
@@ -121,8 +96,16 @@ describe("testScenarioModel", () => {
         projectId: true,
         createdById: true,
         title: true,
+        details: true,
         createdAt: true,
         updatedAt: true,
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
       },
       skip: 10,
       take: 10,
@@ -130,9 +113,12 @@ describe("testScenarioModel", () => {
     });
 
     const select = findManyMock.mock.calls[0]?.[0] as {
-      select?: Record<string, boolean>;
+      select?: Record<string, unknown>;
     };
     expect(select.select).not.toHaveProperty("contentMd");
+    expect(select.select?.createdBy).toEqual({
+      select: { id: true, name: true, email: true },
+    });
   });
 
   it("uses the project predicate and default pagination for summaries", async () => {
@@ -218,6 +204,17 @@ describe("testScenarioModel", () => {
       "title",
       "contentMd",
     ]);
+  });
+
+  it("passes nullable details updates while preserving omitted fields", async () => {
+    await testScenarioModel.update(scenario.id, scenario.projectId, {
+      details: null,
+    });
+
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: scenario.id },
+      data: { details: null },
+    });
   });
 
   it("preserves omitted fields by passing only supplied authored data", async () => {

--- a/__tests__/prisma/testScenarioMigration.test.ts
+++ b/__tests__/prisma/testScenarioMigration.test.ts
@@ -23,6 +23,13 @@ describe("test-scenario persistence contract", () => {
     ),
     "utf8",
   );
+  const detailsMigration = readFileSync(
+    path.join(
+      process.cwd(),
+      "prisma/migrations/20260904120000_add_test_scenario_details/migration.sql",
+    ),
+    "utf8",
+  );
 
   it("defines a project-owned Markdown record with creator and timestamp fields", () => {
     expect(schema).toMatch(
@@ -81,6 +88,26 @@ describe("test-scenario persistence contract", () => {
     );
     expect(linkMigration).toContain(
       'CREATE INDEX "Assumption_resultErrorId_idx"',
+    );
+  });
+
+  it("adds nullable details without changing existing scenario relations", () => {
+    expect(schema).toMatch(
+      /model TestScenario \{[\s\S]*contentMd\s+String\s+@db\.Text[\s\S]*details\s+String\?\s+@db\.Text/,
+    );
+    expect(detailsMigration).toContain(
+      'ALTER TABLE "TestScenario" ADD COLUMN "details" TEXT;',
+    );
+    expect(detailsMigration).not.toContain("NOT NULL");
+    expect(detailsMigration).not.toContain("DEFAULT");
+    expect(detailsMigration).not.toContain("DROP");
+    expect(detailsMigration).not.toContain("FOREIGN KEY");
+    expect(detailsMigration).not.toContain("CREATE INDEX");
+    expect(migration).toContain(
+      'CONSTRAINT "TestScenario_projectId_fkey" FOREIGN KEY ("projectId")',
+    );
+    expect(migration).toContain(
+      'CONSTRAINT "TestScenario_createdById_fkey" FOREIGN KEY ("createdById")',
     );
   });
 });

--- a/__tests__/schemas/testScenarioSchemas.test.ts
+++ b/__tests__/schemas/testScenarioSchemas.test.ts
@@ -1,15 +1,69 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { updateTestScenarioSchema } from "@/schemas/testScenarioSchemas";
+import {
+  createTestScenarioSchema,
+  updateTestScenarioSchema,
+} from "@/schemas/testScenarioSchemas";
+
+const projectId = "11111111-1111-1111-1111-111111111111";
+
+describe("create test scenario schema", () => {
+  it.each([
+    [
+      { projectId, title: " Scenario ", contentMd: "# Exact" },
+      { projectId, title: "Scenario", contentMd: "# Exact" },
+    ],
+    [
+      {
+        projectId,
+        title: "Scenario",
+        contentMd: "  # Exact\n",
+        details: "  Human-readable details  ",
+      },
+      {
+        projectId,
+        title: "Scenario",
+        contentMd: "  # Exact\n",
+        details: "Human-readable details",
+      },
+    ],
+  ])("accepts %j", (body, expected) => {
+    expect(createTestScenarioSchema.parse(body)).toEqual(expected);
+  });
+
+  it.each([
+    { projectId, title: "Scenario", contentMd: "# Exact", details: "" },
+    { projectId, title: "Scenario", contentMd: "# Exact", details: "   " },
+    { projectId, title: "Scenario", contentMd: "# Exact", details: null },
+    {
+      projectId,
+      title: "Scenario",
+      contentMd: "# Exact",
+      createdById: "22222222-2222-2222-2222-222222222222",
+    },
+  ])("rejects invalid or unsupported input %j", (body) => {
+    expect(createTestScenarioSchema.safeParse(body).success).toBe(false);
+  });
+});
 
 describe("update test scenario schema", () => {
   it.each([
     [{ title: "  Updated title  " }, { title: "Updated title" }],
     [{ contentMd: "  # Updated\n" }, { contentMd: "  # Updated\n" }],
+    [{ details: "  Updated details  " }, { details: "Updated details" }],
+    [{ details: null }, { details: null }],
     [
       { title: " Updated ", contentMd: "# Updated" },
       { title: "Updated", contentMd: "# Updated" },
+    ],
+    [
+      { title: " Updated ", details: " Details " },
+      { title: "Updated", details: "Details" },
+    ],
+    [
+      { contentMd: "# Updated", details: null },
+      { contentMd: "# Updated", details: null },
     ],
   ])("accepts %j", (body, expected) => {
     expect(updateTestScenarioSchema.parse(body)).toEqual(expected);
@@ -24,6 +78,10 @@ describe("update test scenario schema", () => {
     { contentMd: null },
     { title: 123 },
     { contentMd: 123 },
+    { details: "" },
+    { details: "   " },
+    { details: 123 },
+    { title: "Updated", details: 123 },
     { unknown: "value" },
     { title: "Updated", unknown: "value" },
     { projectId: "11111111-1111-1111-1111-111111111111" },

--- a/__tests__/services/testScenarioService.test.ts
+++ b/__tests__/services/testScenarioService.test.ts
@@ -8,7 +8,6 @@ import type { TestScenarioSummary } from "@/types/testScenarios";
 
 const mockProjectExists = jest.fn<() => Promise<boolean>>();
 const mockCreate = jest.fn<() => Promise<TestScenario>>();
-const mockFindMany = jest.fn<() => Promise<TestScenario[]>>();
 const mockFindManySummaries = jest.fn<() => Promise<TestScenarioSummary[]>>();
 const mockCount = jest.fn<() => Promise<number>>();
 const mockFindById = jest.fn<() => Promise<TestScenario | null>>();
@@ -16,7 +15,7 @@ const mockUpdate = jest.fn<
   (
     scenarioId: string,
     projectId: string,
-    data: { title?: string; contentMd?: string },
+    data: { title?: string; contentMd?: string; details?: string | null },
   ) => Promise<TestScenario | null>
 >();
 const mockDelete = jest.fn<() => Promise<number>>();
@@ -30,7 +29,6 @@ jest.mock("@/models/projectModel", () => ({
 jest.mock("@/models/testScenarioModel", () => ({
   testScenarioModel: {
     create: mockCreate,
-    findMany: mockFindMany,
     findManySummaries: mockFindManySummaries,
     count: mockCount,
     findById: mockFindById,
@@ -53,6 +51,7 @@ const scenario: TestScenario = {
   createdById: "44444444-4444-4444-4444-444444444444",
   title: "Login",
   contentMd: "# Login\n\n```ts\n  const value = '✓';\n```\n",
+  details: null,
   createdAt: new Date("2026-01-01T00:00:00.000Z"),
   updatedAt: new Date("2026-01-01T00:00:00.000Z"),
 };
@@ -62,13 +61,18 @@ describe("testScenarioService", () => {
     jest.clearAllMocks();
     mockProjectExists.mockResolvedValue(true);
     mockCreate.mockResolvedValue(scenario);
-    mockFindMany.mockResolvedValue([scenario]);
     mockFindManySummaries.mockResolvedValue([
       {
         id: scenario.id,
         projectId: scenario.projectId,
         createdById: scenario.createdById,
         title: scenario.title,
+        details: scenario.details,
+        createdBy: {
+          id: scenario.createdById,
+          name: "Scenario Creator",
+          email: "creator@example.com",
+        },
         createdAt: scenario.createdAt,
         updatedAt: scenario.updatedAt,
       },
@@ -94,8 +98,42 @@ describe("testScenarioService", () => {
       title: "Scenario title",
       contentMd,
       createdById: scenario.createdById,
+      details: null,
     });
     expect(result).toBe(scenario);
+  });
+
+  it("trims populated details while preserving exact Markdown", async () => {
+    const contentMd = "  # Heading\n\n  exact ✓\n";
+
+    await testScenarioService.createScenario({
+      projectId,
+      title: "Scenario title",
+      contentMd,
+      createdById: scenario.createdById,
+      details: "  Human-readable details  ",
+    });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      projectId,
+      title: "Scenario title",
+      contentMd,
+      createdById: scenario.createdById,
+      details: "Human-readable details",
+    });
+  });
+
+  it("rejects blank creation details before persistence", async () => {
+    await expect(
+      testScenarioService.createScenario({
+        projectId,
+        title: "Scenario",
+        contentMd: "content",
+        createdById: scenario.createdById,
+        details: " \t\n ",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("rejects creation for an unknown project before persistence", async () => {
@@ -112,8 +150,8 @@ describe("testScenarioService", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  it("returns stable pagination metadata and forwards page offsets", async () => {
-    mockFindMany.mockResolvedValue([]);
+  it("returns stable summary pagination metadata and forwards page offsets", async () => {
+    mockFindManySummaries.mockResolvedValue([]);
     mockCount.mockResolvedValue(61);
 
     const result = await testScenarioService.listScenarios({
@@ -122,7 +160,7 @@ describe("testScenarioService", () => {
       limit: 30,
     });
 
-    expect(mockFindMany).toHaveBeenCalledWith(projectId, 3, 30);
+    expect(mockFindManySummaries).toHaveBeenCalledWith(projectId, 3, 30);
     expect(mockCount).toHaveBeenCalledWith(projectId);
     expect(result).toEqual({
       scenarios: [],
@@ -139,6 +177,12 @@ describe("testScenarioService", () => {
       projectId: scenario.projectId,
       createdById: scenario.createdById,
       title: scenario.title,
+      details: "Scenario details",
+      createdBy: {
+        id: scenario.createdById,
+        name: "Scenario Creator",
+        email: "creator@example.com",
+      },
       createdAt: scenario.createdAt,
       updatedAt: scenario.updatedAt,
     };
@@ -146,7 +190,7 @@ describe("testScenarioService", () => {
     mockCount.mockResolvedValue(1);
 
     await expect(
-      testScenarioService.listScenarioSummaries({ projectId }),
+      testScenarioService.listScenarios({ projectId }),
     ).resolves.toEqual({
       scenarios: [summary],
       total: 1,
@@ -163,7 +207,7 @@ describe("testScenarioService", () => {
     mockCount.mockResolvedValue(0);
 
     await expect(
-      testScenarioService.listScenarioSummaries({
+      testScenarioService.listScenarios({
         projectId: otherProjectId,
         page: 4,
         limit: 10,
@@ -184,21 +228,21 @@ describe("testScenarioService", () => {
 
   it("rejects invalid summary pagination before querying", async () => {
     await expect(
-      testScenarioService.listScenarioSummaries({
+      testScenarioService.listScenarios({
         projectId,
         page: 0,
         limit: 30,
       }),
     ).rejects.toBeInstanceOf(TestScenarioValidationError);
     await expect(
-      testScenarioService.listScenarioSummaries({
+      testScenarioService.listScenarios({
         projectId,
         page: 1.5,
         limit: 30,
       }),
     ).rejects.toBeInstanceOf(TestScenarioValidationError);
     await expect(
-      testScenarioService.listScenarioSummaries({
+      testScenarioService.listScenarios({
         projectId,
         page: 1,
         limit: 101,
@@ -209,7 +253,7 @@ describe("testScenarioService", () => {
   });
 
   it("returns an empty page for an unknown project without disclosing records", async () => {
-    mockFindMany.mockResolvedValue([]);
+    mockFindManySummaries.mockResolvedValue([]);
     mockCount.mockResolvedValue(0);
 
     const result = await testScenarioService.listScenarios({
@@ -218,7 +262,7 @@ describe("testScenarioService", () => {
 
     expect(result.scenarios).toEqual([]);
     expect(result.totalPages).toBe(0);
-    expect(mockFindMany).toHaveBeenCalledWith(otherProjectId, 1, 30);
+    expect(mockFindManySummaries).toHaveBeenCalledWith(otherProjectId, 1, 30);
   });
 
   it("classifies cross-project detail access as not found", async () => {
@@ -265,6 +309,30 @@ describe("testScenarioService", () => {
 
     expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
       contentMd,
+    });
+  });
+
+  it("updates only details after trimming and preserves omitted authored fields", async () => {
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      details: "  Updated details  ",
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      details: "Updated details",
+    });
+  });
+
+  it("clears details explicitly without changing omitted fields", async () => {
+    await testScenarioService.updateScenario({
+      scenarioId: scenario.id,
+      projectId,
+      details: null,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(scenario.id, projectId, {
+      details: null,
     });
   });
 
@@ -337,6 +405,20 @@ describe("testScenarioService", () => {
         scenarioId: scenario.id,
         projectId,
         contentMd: "",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        details: "   ",
+      }),
+    ).rejects.toBeInstanceOf(TestScenarioValidationError);
+    await expect(
+      testScenarioService.updateScenario({
+        scenarioId: scenario.id,
+        projectId,
+        details: 123 as unknown as string,
       }),
     ).rejects.toBeInstanceOf(TestScenarioValidationError);
     expect(mockUpdate).not.toHaveBeenCalled();

--- a/__tests__/test-scenarios/testScenarioWorkflow.test.ts
+++ b/__tests__/test-scenarios/testScenarioWorkflow.test.ts
@@ -25,6 +25,7 @@ jest.mock("@/models/testScenarioModel", () => ({
       title: string;
       contentMd: string;
       createdById: string;
+      details?: string | null;
     }) => {
       mockNextId += 1;
       const scenario: TestScenario = {
@@ -33,21 +34,41 @@ jest.mock("@/models/testScenarioModel", () => ({
         createdById: data.createdById,
         title: data.title,
         contentMd: data.contentMd,
+        details: data.details ?? null,
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
         updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       };
       mockScenarios.push(scenario);
       return Promise.resolve(scenario);
     }),
-    findMany: jest.fn(
+    findManySummaries: jest.fn(
       (projectId: string, pageInput?: number, limitInput?: number) => {
         const page = pageInput ?? 1;
         const limit = limitInput ?? 30;
-      const matching = mockScenarios
-        .filter((scenario) => scenario.projectId === projectId)
-        .sort((left, right) => right.id.localeCompare(left.id));
-      const start = (page - 1) * limit;
-      return Promise.resolve(matching.slice(start, start + limit));
+        const matching = mockScenarios
+          .filter((scenario) => scenario.projectId === projectId)
+          .sort(
+            (left, right) =>
+              right.createdAt.getTime() - left.createdAt.getTime() ||
+              right.id.localeCompare(left.id),
+          );
+        const start = (page - 1) * limit;
+        return Promise.resolve(
+          matching.slice(start, start + limit).map((scenario) => ({
+            id: scenario.id,
+            projectId: scenario.projectId,
+            createdById: scenario.createdById,
+            title: scenario.title,
+            details: scenario.details,
+            createdBy: {
+              id: scenario.createdById,
+              name: "Scenario Creator",
+              email: "creator@example.com",
+            },
+            createdAt: scenario.createdAt,
+            updatedAt: scenario.updatedAt,
+          })),
+        );
       },
     ),
     count: jest.fn((projectId: string) =>
@@ -67,7 +88,7 @@ jest.mock("@/models/testScenarioModel", () => ({
       (
         id: string,
         projectId: string,
-        data: { title?: string; contentMd?: string },
+        data: { title?: string; contentMd?: string; details?: string | null },
       ) => {
         const scenario = mockScenarios.find(
           (candidate) => candidate.id === id && candidate.projectId === projectId,
@@ -125,7 +146,7 @@ describe("test-scenario project-isolated workflow", () => {
         projectId: projectA,
         title: "  First  ",
         contentMd: exactMarkdown,
-        createdById: spoofedCreatorId,
+        details: "  First details  ",
       },
     });
     const second = await executeController(testScenarioController.create, {
@@ -143,6 +164,7 @@ describe("test-scenario project-isolated workflow", () => {
     expect((first.body as TestScenario).title).toBe("First");
     expect((first.body as TestScenario).createdById).toBe(creatorId);
     expect((first.body as TestScenario).createdById).not.toBe(spoofedCreatorId);
+    expect((first.body as TestScenario).details).toBe("First details");
     expect((first.body as TestScenario).contentMd).toBe(exactMarkdown);
 
     const pageOne = await executeController(testScenarioController.list, {
@@ -155,6 +177,24 @@ describe("test-scenario project-isolated workflow", () => {
       totalPages: 2,
     }));
     expect((pageOne.body as { scenarios: TestScenario[] }).scenarios).toHaveLength(1);
+    const summary = (pageOne.body as {
+      scenarios: Array<Record<string, unknown>>;
+    }).scenarios[0];
+    expect(Object.keys(summary ?? {}).sort()).toEqual([
+      "createdAt",
+      "createdBy",
+      "createdById",
+      "details",
+      "id",
+      "projectId",
+      "title",
+      "updatedAt",
+    ]);
+    expect(summary?.createdBy).toEqual({
+      id: creatorId,
+      name: "Scenario Creator",
+      email: "creator@example.com",
+    });
 
     const pageTwo = await executeController(testScenarioController.list, {
       query: { projectId: projectA, page: "2", limit: "1" },
@@ -228,6 +268,31 @@ describe("test-scenario project-isolated workflow", () => {
     expect(updatedScenario.updatedAt.getTime()).toBeGreaterThan(
       original.updatedAt.getTime(),
     );
+
+    const detailsUpdated = await executeController(
+      testScenarioController.update,
+      {
+        method: "PATCH",
+        params: { scenarioId: original.id },
+        query: { projectId: projectA },
+        body: { details: "  Revised details  " },
+      },
+    );
+    const detailsScenario = detailsUpdated.body as TestScenario;
+    expect(detailsUpdated.statusCode).toBe(200);
+    expect(detailsScenario.details).toBe("Revised details");
+    expect(detailsScenario.contentMd).toBe(exactMarkdown);
+    expect(detailsScenario.id).toBe(original.id);
+    expect(detailsScenario.createdById).toBe(original.createdById);
+
+    const cleared = await executeController(testScenarioController.update, {
+      method: "PATCH",
+      params: { scenarioId: original.id },
+      query: { projectId: projectA },
+      body: { details: null },
+    });
+    expect(cleared.statusCode).toBe(200);
+    expect((cleared.body as TestScenario).details).toBeNull();
 
     const detail = await executeController(testScenarioController.getById, {
       params: { scenarioId: original.id },

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -107,6 +107,20 @@ resources.
 the catalog-provided `downloadUrl` or directly to
 `GET /api/v2/skills/{id}/archive`.
 
+## Test Scenario Routes
+
+Test Scenario list responses are lightweight summaries. Each item contains
+`id`, `projectId`, `createdById`, `title`, nullable plain-text `details`, a
+`createdBy` object containing only `id`, `name`, and `email`, `createdAt`, and
+`updatedAt`; list items no longer contain `contentMd`.
+
+This is a breaking REST response change for dependent clients. Regenerate
+client types and hooks from the final `/api/openapi.json` document, and use
+`GET /api/v2/test-scenarios/{scenarioId}?projectId=...` when complete Markdown
+is required. Create, detail, and update responses continue to return exact
+`contentMd` and nullable `details`; details-only updates trim non-null values,
+accept `null` to clear them, and preserve omitted fields.
+
 ## Related Documentation
 
 - [How to Inspect the MCP Server](INSPECT_MCP_SERVER.md)

--- a/docs/INSPECT_MCP_SERVER.md
+++ b/docs/INSPECT_MCP_SERVER.md
@@ -46,14 +46,17 @@ After connecting with a valid MCP bearer token:
    UUIDs. Confirm Result and Issue pagination fields are separate and bounded
    from 1 through 100.
 3. Invoke the list tool with a project UUID and no pagination fields. Verify
-   the response text is JSON with page 1, limit 30, and summary records that
-   do not contain Markdown.
+   the response text is JSON with page 1, limit 30, and lightweight summary
+   records containing `details` and a `createdBy` object with only `id`, `name`,
+   and `email`; summaries must not contain Markdown or other User fields.
 4. Invoke the detail tool with the same project and a scenario UUID. Verify
-   the response contains raw Markdown plus separate `resultEvidence` and
-   `issueEvidence` pagination envelopes.
-5. For a disposable scenario, invoke the update tool with a title or Markdown
-   field, then invoke the delete tool and verify its explicit `deleted: true`
-   acknowledgement. Cross-project IDs should produce a standard MCP error.
+   the response contains nullable `details`, raw Markdown plus separate
+   `resultEvidence` and `issueEvidence` pagination envelopes.
+5. For a disposable scenario, invoke the update tool with a title, Markdown,
+   or non-blank details field. Verify details are trimmed, `null` clears it,
+   and omitted fields are preserved. Then invoke the delete tool and verify
+   its explicit `deleted: true` acknowledgement. Cross-project IDs should
+   produce a standard MCP error.
 
 The tool-call JSON-RPC shape used by inspector-compatible clients is:
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -206,12 +206,12 @@ returned using the standard MCP error response with `isError: true`.
 
 #### `list-test-scenarios`
 - **Source File:** `src/mcp/tools/test-scenarios.ts`
-- **Description:** List compact Test Scenario summaries for one project
+- **Description:** List lightweight Test Scenario summaries for one project
 - **Parameters:**
   - `projectId` (required): Project UUID
   - `page` (optional): Positive integer page number (default: 1)
   - `limit` (optional): Integer from 1 through 100 (default: 30)
-- **Response:** Pagination envelope containing `scenarios`, `total`, `page`, `limit`, and `totalPages`. Each summary contains `id`, `projectId`, `createdById`, `title`, `createdAt`, and `updatedAt`; Markdown is omitted.
+- **Response:** Pagination envelope containing `scenarios`, `total`, `page`, `limit`, and `totalPages`. Each summary contains exactly `id`, `projectId`, `createdById`, `title`, `details`, `createdBy`, `createdAt`, and `updatedAt`. `createdBy` contains only `id`, `name`, and `email`; `contentMd` and all other User fields are omitted from the list query and response.
 
 #### `get-test-scenario`
 - **Source File:** `src/mcp/tools/test-scenarios.ts`
@@ -223,7 +223,7 @@ returned using the standard MCP error response with `isError: true`.
   - `resultLimit` (optional): Result evidence limit from 1 through 100 (default: 30)
   - `issuePage` (optional): Positive integer observed-Issue evidence page (default: 1)
   - `issueLimit` (optional): Observed-Issue evidence limit from 1 through 100 (default: 30)
-- **Response:** `{ scenario, resultEvidence, issueEvidence }`. `scenario` includes the complete persisted record and exact `contentMd`. Each evidence envelope contains its scenario/project IDs, `linkedSpecCount`, collection, `total`, `page`, `limit`, and `totalPages`. Result evidence is derived from Results belonging to linked same-project Specs; Issue evidence is deduplicated from observed Issues.
+- **Response:** `{ scenario, resultEvidence, issueEvidence }`. `scenario` includes the complete persisted record, nullable `details`, and exact `contentMd`. Each evidence envelope contains its scenario/project IDs, `linkedSpecCount`, collection, `total`, `page`, `limit`, and `totalPages`. Result evidence is derived from Results belonging to linked same-project Specs; Issue evidence is deduplicated from observed Issues.
 
 #### `update-test-scenario`
 - **Source File:** `src/mcp/tools/test-scenarios.ts`
@@ -233,7 +233,8 @@ returned using the standard MCP error response with `isError: true`.
   - `projectId` (required): Owning project UUID
   - `title` (optional): Non-blank replacement title
   - `contentMd` (optional): Non-empty Markdown replacement
-- **Response:** The complete persisted Test Scenario. At least one editable field is required; supplied titles are trimmed and supplied Markdown is preserved exactly. Scenario metadata and project ownership cannot be changed.
+  - `details` (optional): Non-blank plain-text details; surrounding whitespace is trimmed, or `null` to clear it
+- **Response:** The complete persisted Test Scenario, including nullable `details` and exact `contentMd`. At least one editable field is required; omitted fields are preserved. Scenario metadata and project ownership cannot be changed.
 
 #### `delete-test-scenario`
 - **Source File:** `src/mcp/tools/test-scenarios.ts`

--- a/openspec/changes/add-test-scenario-summaries/.openspec.yaml
+++ b/openspec/changes/add-test-scenario-summaries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/add-test-scenario-summaries/design.md
+++ b/openspec/changes/add-test-scenario-summaries/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Test Scenarios currently persist a required title, raw `contentMd`, creator ID, and project ownership. REST list requests use the full-row query and expose `contentMd`, while MCP list requests use a separate compact projection. Neither path exposes descriptive `details` or a populated creator summary. The change spans Prisma, validation, MVC layers, REST, MCP, OpenAPI, and generated-client compatibility.
+
+The existing creator relation is required and protected by an `ON DELETE RESTRICT` foreign key. User deletion and orphaned creator recovery are therefore separate lifecycle concerns rather than list-response behavior for this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist optional normalized plain-text `details` metadata without changing raw Markdown semantics.
+- Use one project-scoped summary query and service path for REST and MCP lists.
+- Return safe creator data containing only `id`, `name`, and `email` while retaining `createdById`.
+- Guarantee that list queries neither select nor return `contentMd`.
+- Keep pagination, deterministic ordering, project isolation, and full-detail behavior stable.
+- Publish accurate runtime, MCP, and OpenAPI contracts for the new shapes.
+
+**Non-Goals:**
+
+- Handling user deletion, orphaned Test Scenario creators, or changing the creator foreign key.
+- Rendering, deriving, or truncating Markdown into `details`.
+- Interpreting or sanitizing `details` as Markdown or HTML.
+- Search, filtering, revision history, or creator reassignment.
+- Regenerating or changing dependent client repositories in this backend change.
+
+## Decisions
+
+### Store details as a nullable text column
+
+Add `details String? @db.Text` to `TestScenario` through a migration that adds a nullable column without a backfill. Existing records therefore read as `details: null`, avoiding a fabricated summary and allowing a safe additive database deployment.
+
+Alternative considered: derive a preview from `contentMd`. This would couple list behavior to Markdown parsing/truncation, prevent author-controlled summaries, and still risk loading the full body.
+
+### Normalize non-null details at the service boundary
+
+Creation accepts omitted `details` or a string containing at least one non-whitespace character. Partial updates accept a non-blank string, `null`, or omission. Non-null values are trimmed before persistence; `null` clears the field; omission preserves it. A details-only update is valid, and unsupported/read-only fields remain rejected.
+
+The service repeats the invariant so REST and MCP callers receive equivalent behavior even if validation is bypassed internally. `details` remains ordinary text; output consumers are responsible for rendering it as text rather than executable markup.
+
+Alternative considered: preserve details byte-for-byte like `contentMd`. Details is summary metadata rather than authored source, so trimming gives the non-blank contract predictable semantics without changing the explicit exact-preservation guarantee for Markdown.
+
+### Use one summary projection for REST and MCP
+
+Replace the separate full REST list and compact MCP list paths with one model selection and one service method. The Prisma selection contains only:
+
+- `id`
+- `projectId`
+- `createdById`
+- `title`
+- `details`
+- `createdAt`
+- `updatedAt`
+- `createdBy: { id, name, email }`
+
+The selection itself is the performance and data-exposure boundary: `contentMd` is not fetched and is not removed after retrieval. Both REST and MCP handlers delegate to the same service path and preserve the existing count query, page/limit rules, project predicate, and `createdAt DESC, id DESC` ordering.
+
+Alternative considered: keep two service methods or strip `contentMd` in the controller. Both approaches permit contract drift and the latter still transfers every Markdown body from PostgreSQL.
+
+### Keep creator attribution required in this contract
+
+Each summary exposes both the existing `createdById` and a required `createdBy` object with exactly `id`, `name`, and `email`. The model query selects only those user fields rather than loading a complete User record or reusing a serializer that first receives sensitive columns. Tests assert `createdBy.id === createdById` and the absence of password, token, role, status, and integration fields.
+
+The current required relation and restrictive foreign key make an unresolved creator invalid database state. Changing deletion semantics or defining a nullable/tombstone creator is deferred to a separate issue.
+
+Alternative considered: include the existing Issue user summary with `createdAt`. The catalog needs only identity and display/contact fields, so the narrower projection avoids an unnecessary field.
+
+### Preserve complete scenario responses
+
+Create, REST detail, REST update, MCP detail, and MCP update continue returning the complete scenario record with exact `contentMd`; they additionally return nullable `details`. Updating only `details` must not alter `contentMd`, title, creator, project, creation time, or evidence links.
+
+`createdBy` is added to list summaries only. Full scenario responses continue identifying the creator through `createdById`, avoiding an unrelated expansion of every response shape.
+
+### Represent the breaking list contract explicitly
+
+OpenAPI defines a dedicated `TestScenarioSummary` and makes `TestScenarioListResponse.scenarios` reference it. The full `TestScenario` schema gains nullable `details`, and create/update schemas describe the new inputs, including explicit clearing. MCP input schemas and help text expose equivalent update semantics.
+
+Dependent clients must regenerate from the final OpenAPI document. Consumers that need Markdown must call the detail endpoint rather than relying on list items.
+
+## Risks / Trade-offs
+
+- [Breaking REST response for clients that read `contentMd` from lists] → Mark the change as breaking, regenerate dependent clients, and require detail reads for Markdown.
+- [Runtime and OpenAPI update validation diverge] → Cover omitted, string, `null`, details-only, blank, and unknown-field cases in both schema and generated-contract tests.
+- [Sensitive User fields leak through relation loading] → Use an explicit nested Prisma `select` and assert the exact creator keys in model, service, route, MCP, and OpenAPI tests.
+- [REST and MCP summaries drift again] → Expose a single summary type, model projection, and service method shared by both transports.
+- [Text is rendered as markup by a consumer] → Document `details` as plain text and keep Markdown/HTML interpretation out of the backend contract.
+- [Rollback after clients depend on the new schema] → Treat code/OpenAPI rollback as coordinated; the nullable database column may safely remain during rollback.
+
+## Migration Plan
+
+1. Add and apply the nullable `details` column migration; existing rows require no backfill.
+2. Deploy backend code that reads/writes `details` and serves the shared summary contract.
+3. Publish the final OpenAPI document and regenerate dependent clients.
+4. Update list consumers to use `details` and `createdBy`, and to request detail when Markdown is needed.
+
+Database rollback may leave the unused nullable column in place. Dropping it is optional and must occur only after confirming no deployed backend writes it.
+
+## Open Questions
+
+None. Creator projection, details normalization, and creator-deletion scope are settled for this change.

--- a/openspec/changes/add-test-scenario-summaries/proposal.md
+++ b/openspec/changes/add-test-scenario-summaries/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Test Scenario list responses currently load and expose the full Markdown body while omitting the human-readable summary and creator information needed by catalog clients. A shared lightweight summary contract will reduce unnecessary database and API payload work while giving REST and MCP consumers consistent metadata.
+
+## What Changes
+
+- Add nullable `details` plain-text metadata to Test Scenarios, defaulting existing records to `null`.
+- Accept optional non-blank `details` during creation and allow partial updates to set, preserve, or explicitly clear it with `null`.
+- Include `details` in create, detail, update, REST-list, and MCP-list responses while preserving exact `contentMd` on full scenario responses.
+- **BREAKING**: Change `GET /api/v2/test-scenarios` items to a dedicated lightweight summary that does not include `contentMd`.
+- Add a required `createdBy` summary containing only `id`, `name`, and `email` to REST and MCP list items while retaining `createdById`.
+- Back REST and MCP lists with the same project-scoped, deterministically ordered model/service query that selects only summary fields.
+- Update runtime validation, TypeScript types, MCP schemas, OpenAPI schemas, migration coverage, and REST/MCP regression tests.
+- Keep creator deletion and unresolved-creator behavior outside this change for separate issue tracking.
+
+## Capabilities
+
+### New Capabilities
+- `test-scenario-summaries`: Nullable Test Scenario details metadata and the shared lightweight REST/MCP list contract, including safe creator summaries and full-detail Markdown preservation.
+
+### Modified Capabilities
+
+None. The earlier Test Scenario capabilities are still represented by active changes rather than promoted specifications under `openspec/specs`.
+
+## Impact
+
+- Persistence: Prisma `TestScenario` model and a safe nullable-column migration.
+- MVC layers: Test Scenario model projections, service methods, controllers, schemas, and shared response types.
+- MCP: scenario list, detail, and update schemas/handlers through the shared service boundary.
+- API contract: Test Scenario OpenAPI request/response schemas and generated-client consumers.
+- Consumers: catalog clients must regenerate from the final OpenAPI document and fetch scenario detail when `contentMd` is required.
+- Compatibility: pagination envelope, project isolation, ordering, authenticated creator attribution, and exact Markdown behavior remain unchanged.

--- a/openspec/changes/add-test-scenario-summaries/specs/test-scenario-summaries/spec.md
+++ b/openspec/changes/add-test-scenario-summaries/specs/test-scenario-summaries/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Test Scenarios store optional plain-text details
+The system SHALL persist each Test Scenario with nullable `details` metadata distinct from its raw `contentMd`. Existing records SHALL migrate with `details` equal to `null`, and the system SHALL NOT derive details from Markdown.
+
+#### Scenario: Existing records migrate safely
+- **WHEN** the migration is applied to a database containing Test Scenarios
+- **THEN** every existing scenario remains readable with `details` equal to `null`
+- **AND** its title, `contentMd`, project, creator, timestamps, and evidence links remain unchanged
+
+#### Scenario: Scenario is created without details
+- **WHEN** an authenticated client creates a valid Test Scenario and omits `details`
+- **THEN** the scenario is created with `details` equal to `null`
+
+#### Scenario: Scenario is created with details
+- **WHEN** an authenticated client creates a valid Test Scenario with a `details` string containing non-whitespace characters
+- **THEN** the system trims surrounding whitespace and persists the normalized details
+- **AND** preserves the submitted `contentMd` exactly
+
+#### Scenario: Blank creation details are rejected
+- **WHEN** an authenticated client creates a Test Scenario with empty or whitespace-only `details`
+- **THEN** the system rejects the request with HTTP 400
+- **AND** creates no scenario
+
+### Requirement: Details support strict partial updates and explicit clearing
+REST and MCP partial updates SHALL accept `details` as an editable field. A non-null value SHALL contain a non-whitespace character and SHALL be trimmed before persistence, `null` SHALL clear the field, and omission SHALL preserve the stored value. At least one of `title`, `contentMd`, or `details` SHALL be supplied.
+
+#### Scenario: Update only details
+- **WHEN** a client updates an existing project-scoped scenario with valid non-null `details` and omits `title` and `contentMd`
+- **THEN** the system persists the trimmed details
+- **AND** preserves the title and exact Markdown content
+
+#### Scenario: Clear details explicitly
+- **WHEN** a client updates an existing project-scoped scenario with `details` equal to `null`
+- **THEN** the system persists `details` as `null`
+- **AND** preserves all omitted authored fields
+
+#### Scenario: Omitted details remain unchanged
+- **WHEN** a client updates only the title or `contentMd`
+- **THEN** the existing `details` value remains unchanged
+
+#### Scenario: Invalid details update is rejected
+- **WHEN** a client supplies empty, whitespace-only, or non-string non-null `details`
+- **THEN** the system rejects the update without modifying the scenario
+
+#### Scenario: Empty update remains invalid
+- **WHEN** a client supplies none of `title`, `contentMd`, or `details`
+- **THEN** the system rejects the update without modifying the scenario
+
+### Requirement: REST and MCP expose one lightweight scenario summary
+`GET /api/v2/test-scenarios` and `list-test-scenarios` SHALL use the same model and service summary path. Each list item SHALL contain exactly `id`, `projectId`, `createdById`, `title`, `details`, `createdBy`, `createdAt`, and `updatedAt`, and SHALL NOT contain `contentMd`.
+
+#### Scenario: REST returns lightweight summaries
+- **WHEN** an authenticated client lists Test Scenarios for a valid project through REST
+- **THEN** every item has the documented summary fields
+- **AND** no item contains `contentMd`
+
+#### Scenario: MCP returns the aligned summaries
+- **WHEN** an authenticated MCP client lists Test Scenarios for the same project and page
+- **THEN** every item has the same summary shape and metadata semantics as REST
+- **AND** no item contains `contentMd`
+
+#### Scenario: List query excludes Markdown at the database boundary
+- **WHEN** either transport lists Test Scenarios
+- **THEN** the database query selects only the documented scenario and creator summary fields
+- **AND** does not select or load `contentMd`
+
+### Requirement: Summary creator data is safe and consistent
+Every Test Scenario summary SHALL retain `createdById` and SHALL contain a required `createdBy` object with exactly `id`, `name`, and `email`. The nested creator ID SHALL equal `createdById`, and no other User fields SHALL be selected or exposed.
+
+#### Scenario: Creator is populated for a summary
+- **WHEN** a scenario list contains a valid Test Scenario
+- **THEN** its `createdBy` object identifies the creating user by `id`, `name`, and `email`
+- **AND** `createdBy.id` equals the scenario's `createdById`
+
+#### Scenario: Sensitive creator fields remain private
+- **WHEN** REST or MCP serializes a Test Scenario summary
+- **THEN** `createdBy` contains no password hash, MCP token, authentication identifier, role, status, integration setting, or timestamp field
+
+### Requirement: Summary listing preserves project isolation and pagination
+The shared summary path SHALL preserve the existing project predicate, pagination envelope, validation limits, and deterministic ordering by creation time descending and then ID descending.
+
+#### Scenario: Only the requested project is returned
+- **WHEN** scenarios exist in multiple projects and a client lists one project
+- **THEN** every returned summary belongs to the requested project
+- **AND** no creator or scenario data from another project is returned through that query
+
+#### Scenario: Pagination behavior is unchanged
+- **WHEN** a client lists summaries with valid page and limit inputs
+- **THEN** the response contains `scenarios`, `total`, `page`, `limit`, and `totalPages` using the existing rules
+- **AND** records are ordered by `createdAt` descending and then `id` descending
+
+#### Scenario: Empty project page is stable
+- **WHEN** a valid project context contains no matching scenarios
+- **THEN** REST and MCP return an empty `scenarios` array with zero pagination totals
+
+### Requirement: Full scenario responses preserve Markdown and expose details
+Create, REST detail, REST update, MCP detail, and MCP update responses SHALL contain the complete Test Scenario including nullable `details` and exact raw `contentMd`. Adding or changing details SHALL NOT change the established Markdown preservation behavior.
+
+#### Scenario: Detail retains complete Markdown
+- **WHEN** a client retrieves a scenario through REST or MCP detail
+- **THEN** the response contains its current nullable `details`
+- **AND** returns the complete `contentMd` exactly as persisted
+
+#### Scenario: Create and update return the persisted details
+- **WHEN** a create or partial update succeeds
+- **THEN** the response contains the resulting `details` value and complete exact `contentMd`
+
+#### Scenario: Details-only update preserves immutable and linked data
+- **WHEN** a client changes or clears only `details`
+- **THEN** the scenario retains its ID, project ID, creator ID, title, creation timestamp, and exact `contentMd`
+- **AND** all Spec links and execution evidence remain unchanged
+
+### Requirement: OpenAPI and MCP contracts describe the final shapes
+The generated OpenAPI document SHALL define a dedicated Test Scenario summary schema without `contentMd`, SHALL use it in the REST list response, and SHALL describe nullable `details` in full responses and create/update inputs. MCP schemas and tool descriptions SHALL expose equivalent list, detail, and update behavior.
+
+#### Scenario: OpenAPI list schema is lightweight
+- **WHEN** the backend generates its OpenAPI document
+- **THEN** `TestScenarioListResponse.scenarios` references the dedicated summary schema
+- **AND** that summary requires `createdBy`, retains `createdById`, and excludes `contentMd`
+
+#### Scenario: Contract documents details lifecycle
+- **WHEN** a client inspects the REST or MCP update contract
+- **THEN** it can distinguish a non-null details update, explicit `null` clearing, and omission
+- **AND** the contract rejects unsupported or read-only update fields

--- a/openspec/changes/add-test-scenario-summaries/tasks.md
+++ b/openspec/changes/add-test-scenario-summaries/tasks.md
@@ -1,0 +1,43 @@
+## 1. Persistence and Shared Types
+
+- [x] 1.1 Add nullable `details String? @db.Text` to the Prisma `TestScenario` model and create a migration that leaves existing rows as `null` without changing current relations or indexes.
+- [x] 1.2 Regenerate the Prisma client and extend Test Scenario create, update, full-response, summary, and MCP types with the settled nullable-details semantics.
+- [x] 1.3 Define the required Test Scenario creator summary type with exactly `id`, `name`, and `email`, retaining `createdById` on list summaries.
+- [x] 1.4 Extend migration regression coverage to verify the nullable column, safe existing-row behavior, and unchanged project/creator foreign keys.
+
+## 2. Validation and Service Semantics
+
+- [x] 2.1 Extend REST create validation to accept omitted or non-blank string `details`, reject empty or whitespace-only values, and continue rejecting unsupported creator input.
+- [x] 2.2 Extend strict REST partial-update validation to accept title, `contentMd`, `details`, or valid combinations; support `details: null`; and reject empty updates, blank details, malformed values, and read-only fields.
+- [x] 2.3 Extend model create/update data boundaries to persist nullable details while preserving omitted fields.
+- [x] 2.4 Update the Test Scenario service to trim non-null details, store omitted creation details as `null`, support details-only updates and explicit clearing, and preserve exact Markdown plus immutable metadata.
+- [x] 2.5 Add schema and service tests for create omission, normalization, blank rejection, details-only update, clearing, omission preservation, mixed-field updates, and unchanged Markdown/evidence behavior.
+
+## 3. Shared Lightweight Summary Path
+
+- [x] 3.1 Replace the current summary selection with an explicit Prisma projection containing only scenario summary fields and nested creator `id`, `name`, and `email`, excluding `contentMd` and all other User fields.
+- [x] 3.2 Consolidate REST and MCP listing behind one typed service method using the shared projection while preserving project filtering, count, pagination validation, and deterministic ordering.
+- [x] 3.3 Update the REST list controller to call the shared summary service path and remove or retire the obsolete full-row list path without affecting detail queries.
+- [x] 3.4 Add model, service, and controller tests proving REST/MCP shape alignment, exact creator keys, `createdBy.id` consistency, database-level Markdown exclusion, project isolation, ordering, pagination, and empty pages.
+
+## 4. MCP Contracts and Tools
+
+- [x] 4.1 Extend the MCP update schema and parameter types with optional nullable `details` while preserving strict identifiers, unsupported-field rejection, and service-level at-least-one-field validation.
+- [x] 4.2 Ensure MCP list uses the shared summary response and MCP detail/update responses expose nullable `details` with complete exact `contentMd`.
+- [x] 4.3 Update Test Scenario MCP tool descriptions and inspector documentation to describe lightweight list fields, safe creator data, details normalization/clearing, and detail-only Markdown retrieval.
+- [x] 4.4 Add MCP schema, handler, tool, registration, and authenticated transport tests for summary shape, sensitive-field exclusion, details set/clear/omit behavior, full detail Markdown, and error handling.
+
+## 5. OpenAPI and REST Contract
+
+- [x] 5.1 Add nullable `details` to the full Test Scenario schema and creation request, and model strict partial-update alternatives including details-only strings and explicit `null` clearing.
+- [x] 5.2 Define and register a dedicated `TestScenarioSummary` schema containing the agreed scenario fields and required `{ id, name, email }` creator object without `contentMd`.
+- [x] 5.3 Change `TestScenarioListResponse.scenarios` to reference the dedicated summary schema while preserving its pagination envelope and bearer-authenticated route documentation.
+- [x] 5.4 Add OpenAPI contract tests for the breaking list shape, exact creator projection, nullable details lifecycle, strict update alternatives, full detail Markdown, and absence of sensitive User fields.
+- [x] 5.5 Update REST route/controller/workflow tests to cover create, list, detail, and update response shapes across null and populated details without regressing authentication or project isolation.
+
+## 6. Verification and Handoff
+
+- [x] 6.1 Run focused Test Scenario migration, schema, model, service, controller, route, OpenAPI, MCP, and workflow tests.
+- [x] 6.2 Run `npm run type-check`, `npm run lint`, `npm test`, and `npm run build`, resolving all new failures without masking unrelated warnings or generated-contract drift.
+- [x] 6.3 Run `openspec validate add-test-scenario-summaries --type change --strict --no-interactive` and `git diff --check`.
+- [x] 6.4 Document the breaking REST list change for dependent-client regeneration and note that creator deletion/unresolved-creator handling remains assigned to a separate issue.

--- a/prisma/migrations/20260904120000_add_test_scenario_details/migration.sql
+++ b/prisma/migrations/20260904120000_add_test_scenario_details/migration.sql
@@ -1,0 +1,2 @@
+-- Add nullable plain-text metadata without backfilling existing scenarios.
+ALTER TABLE "TestScenario" ADD COLUMN "details" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -222,6 +222,7 @@ model TestScenario {
   updatedAt   DateTime @updatedAt
   title       String
   contentMd   String   @db.Text
+  details     String?  @db.Text
   createdById String   @db.Uuid
 
   project   Project @relation(fields: [projectId], references: [id])

--- a/src/handlers/mcpTestScenarioHandler.ts
+++ b/src/handlers/mcpTestScenarioHandler.ts
@@ -19,7 +19,7 @@ export const mcpTestScenarioHandler = {
   async listTestScenarios(
     params: TestScenarioMcpListParams,
   ): Promise<TestScenarioSummaryListResponse> {
-    return await testScenarioService.listScenarioSummaries(params);
+    return await testScenarioService.listScenarios(params);
   },
 
   async getTestScenario(

--- a/src/lib/openapi/testScenarios.ts
+++ b/src/lib/openapi/testScenarios.ts
@@ -13,6 +13,7 @@ const TestScenarioSchema = z
     createdById: z.string().uuid(),
     title: z.string(),
     contentMd: z.string(),
+    details: z.string().nullable(),
     createdAt: z.string(),
     updatedAt: z.string(),
   })
@@ -21,10 +22,41 @@ const TestScenarioSchema = z
 const CreateTestScenarioRequestSchema = z
   .object({
     projectId: z.string().uuid(),
-    title: z.string().min(1),
+    title: z.string().min(1).regex(/\S/),
     contentMd: z.string().min(1),
+    details: z.string().min(1).regex(/\S/).optional(),
   })
+  .strict()
   .openapi("CreateTestScenarioRequest");
+
+const TestScenarioCreatorSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string(),
+    email: z.string(),
+  })
+  .strict()
+  .openapi("TestScenarioCreatorSummary");
+
+const TestScenarioSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    projectId: z.string().uuid(),
+    createdById: z.string().uuid(),
+    title: z.string(),
+    details: z.string().nullable(),
+    createdBy: TestScenarioCreatorSummarySchema,
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .strict()
+  .openapi("TestScenarioSummary");
+
+const UpdateTestScenarioDetailsSchema = z
+  .string()
+  .min(1)
+  .regex(/\S/)
+  .nullable();
 
 const UpdateTestScenarioRequestSchema = z
   .union([
@@ -32,12 +64,21 @@ const UpdateTestScenarioRequestSchema = z
       .object({
         title: z.string().min(1).regex(/\S/),
         contentMd: z.string().min(1).optional(),
+        details: UpdateTestScenarioDetailsSchema.optional(),
       })
       .strict(),
     z
       .object({
         title: z.string().min(1).regex(/\S/).optional(),
         contentMd: z.string().min(1),
+        details: UpdateTestScenarioDetailsSchema.optional(),
+      })
+      .strict(),
+    z
+      .object({
+        title: z.string().min(1).regex(/\S/).optional(),
+        contentMd: z.string().min(1).optional(),
+        details: UpdateTestScenarioDetailsSchema,
       })
       .strict(),
   ])
@@ -65,7 +106,7 @@ const TestScenarioListQuerySchema = z
 
 const TestScenarioListResponseSchema = z
   .object({
-    scenarios: z.array(TestScenarioSchema),
+    scenarios: z.array(TestScenarioSummarySchema),
     total: z.number().int().nonnegative(),
     page: z.number().int().positive(),
     limit: z.number().int().positive().max(100),
@@ -198,6 +239,11 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
     CreateTestScenarioRequestSchema,
   );
   registry.register(
+    "TestScenarioCreatorSummary",
+    TestScenarioCreatorSummarySchema,
+  );
+  registry.register("TestScenarioSummary", TestScenarioSummarySchema);
+  registry.register(
     "UpdateTestScenarioRequest",
     UpdateTestScenarioRequestSchema,
   );
@@ -291,7 +337,7 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
     method: "patch",
     path: "/api/v2/test-scenarios/{scenarioId}",
     description:
-      "Partially updates a test scenario within a project context. Omitted fields are preserved.",
+      "Partially updates a test scenario within a project context. At least one of title, Markdown, or plain-text details is required; omitted fields are preserved and details may be cleared with null.",
     request: {
       params: TestScenarioIdParamsSchema,
       query: TestScenarioProjectQuerySchema,
@@ -414,7 +460,8 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
   registry.registerPath({
     method: "post",
     path: "/api/v2/test-scenarios",
-    description: "Creates a project-scoped Markdown test scenario.",
+    description:
+      "Creates a project-scoped Markdown test scenario with optional plain-text details.",
     request: {
       body: {
         required: true,
@@ -464,7 +511,8 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
   registry.registerPath({
     method: "get",
     path: "/api/v2/test-scenarios",
-    description: "Lists project-scoped Markdown test scenarios.",
+    description:
+      "Lists lightweight project-scoped Test Scenario summaries without Markdown bodies.",
     request: {
       query: TestScenarioListQuerySchema,
     },
@@ -501,7 +549,8 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
   registry.registerPath({
     method: "get",
     path: "/api/v2/test-scenarios/{scenarioId}",
-    description: "Retrieves a test scenario within a project context.",
+    description:
+      "Retrieves a complete test scenario, including nullable plain-text details and exact raw Markdown, within a project context.",
     request: {
       params: TestScenarioIdParamsSchema,
       query: TestScenarioProjectQuerySchema,
@@ -586,6 +635,7 @@ export function registerTestScenarioRoutes(registry: OpenAPIRegistry): void {
 
 export {
   CreateTestScenarioRequestSchema,
+  TestScenarioCreatorSummarySchema,
   UpdateTestScenarioRequestSchema,
   TestScenarioEvidenceQuerySchema,
   TestScenarioIdParamsSchema,
@@ -602,4 +652,5 @@ export {
   TestScenarioSpecLinkListResponseSchema,
   TestScenarioSpecLinkResponseSchema,
   TestScenarioSchema,
+  TestScenarioSummarySchema,
 };

--- a/src/mcp/schemas/testScenarioSchemas.ts
+++ b/src/mcp/schemas/testScenarioSchemas.ts
@@ -33,6 +33,13 @@ export const updateTestScenarioSchema = z
     projectId: uuid().describe("The UUID of the project"),
     title: z.string().optional(),
     contentMd: z.string().optional(),
+    details: z
+      .string()
+      .trim()
+      .min(1)
+      .nullable()
+      .optional()
+      .describe("Plain-text details; trim surrounding whitespace or use null to clear"),
   })
   .strict() satisfies MCPToolSchema;
 

--- a/src/mcp/tools/test-scenarios.ts
+++ b/src/mcp/tools/test-scenarios.ts
@@ -19,7 +19,7 @@ import type {
 
 export const listTestScenarios = createMcpTool(
   "list-test-scenarios",
-  "List compact Test Scenario summaries for a project. Markdown is available from get-test-scenario.",
+  "List lightweight Test Scenario summaries for a project, including normalized details and safe creator id, name, and email. Markdown is available from get-test-scenario.",
   listTestScenariosSchema,
   async (params: TestScenarioMcpListParams): Promise<MCPToolResponse> => {
     const scenarios = await mcpTestScenarioHandler.listTestScenarios(params);
@@ -30,7 +30,7 @@ export const listTestScenarios = createMcpTool(
 
 export const getTestScenario = createMcpTool(
   "get-test-scenario",
-  "Retrieve a complete project-scoped Test Scenario with raw Markdown and independently paginated Result and observed-Issue evidence.",
+  "Retrieve a complete project-scoped Test Scenario with nullable details, raw Markdown, and independently paginated Result and observed-Issue evidence.",
   getTestScenarioSchema,
   async (params: TestScenarioMcpGetParams): Promise<MCPToolResponse> => {
     const scenario = await mcpTestScenarioHandler.getTestScenario(params);
@@ -41,7 +41,7 @@ export const getTestScenario = createMcpTool(
 
 export const updateTestScenario = createMcpTool(
   "update-test-scenario",
-  "Partially update a project-scoped Test Scenario title, Markdown, or both. At least one editable field is required.",
+  "Partially update a project-scoped Test Scenario title, Markdown, or plain-text details. At least one editable field is required; details are trimmed, null clears details, and omitted fields are preserved.",
   updateTestScenarioSchema,
   async (params: TestScenarioMcpUpdateParams): Promise<MCPToolResponse> => {
     const scenario = await mcpTestScenarioHandler.updateTestScenario(params);

--- a/src/models/testScenarioModel.ts
+++ b/src/models/testScenarioModel.ts
@@ -10,11 +10,13 @@ export interface CreateTestScenarioData {
   title: string;
   contentMd: string;
   createdById: string;
+  details?: string | null;
 }
 
 export interface UpdateTestScenarioData {
   title?: string;
   contentMd?: string;
+  details?: string | null;
 }
 
 const projectWhere = (projectId: string): Prisma.TestScenarioWhereInput => ({
@@ -26,8 +28,16 @@ const summarySelect = {
   projectId: true,
   createdById: true,
   title: true,
+  details: true,
   createdAt: true,
   updatedAt: true,
+  createdBy: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
 } satisfies Prisma.TestScenarioSelect;
 
 export const testScenarioModel = {
@@ -37,21 +47,6 @@ export const testScenarioModel = {
   ): Promise<TestScenario> {
     const client = tx ?? dbClient;
     return await client.testScenario.create({ data });
-  },
-
-  async findMany(
-    projectId: string,
-    page = 1,
-    limit = 30,
-    tx?: Prisma.TransactionClient,
-  ): Promise<TestScenario[]> {
-    const client = tx ?? dbClient;
-    return await client.testScenario.findMany({
-      where: projectWhere(projectId),
-      skip: (page - 1) * limit,
-      take: limit,
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-    });
   },
 
   async findManySummaries(

--- a/src/schemas/testScenarioSchemas.ts
+++ b/src/schemas/testScenarioSchemas.ts
@@ -10,12 +10,21 @@ export const createTestScenarioSchema = z
     projectId: uuidSchema,
     title: z.string().trim().min(1, "Title is required"),
     contentMd: z.string().min(1, "contentMd is required"),
-  });
+    details: z.string().trim().min(1, "Details is required").optional(),
+  })
+  .strict();
+
+const updateTestScenarioDetailsSchema = z
+  .string()
+  .trim()
+  .min(1, "Details is required")
+  .nullable();
 
 const updateTestScenarioTitleSchema = z
   .object({
     title: z.string().trim().min(1, "Title is required"),
     contentMd: z.string().min(1, "contentMd is required").optional(),
+    details: updateTestScenarioDetailsSchema.optional(),
   })
   .strict();
 
@@ -23,12 +32,22 @@ const updateTestScenarioContentSchema = z
   .object({
     title: z.string().trim().min(1, "Title is required").optional(),
     contentMd: z.string().min(1, "contentMd is required"),
+    details: updateTestScenarioDetailsSchema.optional(),
+  })
+  .strict();
+
+const updateTestScenarioDetailsOnlySchema = z
+  .object({
+    title: z.string().trim().min(1, "Title is required").optional(),
+    contentMd: z.string().min(1, "contentMd is required").optional(),
+    details: updateTestScenarioDetailsSchema,
   })
   .strict();
 
 export const updateTestScenarioSchema = z.union([
   updateTestScenarioTitleSchema,
   updateTestScenarioContentSchema,
+  updateTestScenarioDetailsOnlySchema,
 ]);
 
 export const testScenarioProjectQuerySchema = z.object({

--- a/src/services/testScenarioService.ts
+++ b/src/services/testScenarioService.ts
@@ -10,13 +10,20 @@ import {
   type ListTestScenariosParams,
   type TestScenarioListResponse,
   type TestScenarioResponse,
-  type TestScenarioSummaryListResponse,
   type UpdateTestScenarioParams,
 } from "@/types/testScenarios";
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 30;
 const MAX_LIMIT = 100;
+
+function normalizeDetails(details: unknown): string {
+  if (typeof details !== "string" || !details.trim()) {
+    throw new TestScenarioValidationError("Details is required");
+  }
+
+  return details.trim();
+}
 
 function validatePagination(page: number, limit: number): void {
   if (!Number.isInteger(page) || page < 1) {
@@ -36,13 +43,16 @@ export const testScenarioService = {
   async createScenario(
     params: CreateTestScenarioParams,
   ): Promise<TestScenarioResponse> {
-    if (!params.title.trim()) {
+    if (typeof params.title !== "string" || !params.title.trim()) {
       throw new TestScenarioValidationError("Title is required");
     }
 
-    if (params.contentMd.length === 0) {
+    if (typeof params.contentMd !== "string" || params.contentMd.length === 0) {
       throw new TestScenarioValidationError("contentMd is required");
     }
+
+    const details =
+      params.details === undefined ? null : normalizeDetails(params.details);
 
     if (!(await projectModel.exists(params.projectId))) {
       throw new TestScenarioNotFoundError(
@@ -55,33 +65,13 @@ export const testScenarioService = {
       title: params.title.trim(),
       contentMd: params.contentMd,
       createdById: params.createdById,
+      details,
     });
   },
 
   async listScenarios(
     params: ListTestScenariosParams,
   ): Promise<TestScenarioListResponse> {
-    const page = params.page ?? DEFAULT_PAGE;
-    const limit = params.limit ?? DEFAULT_LIMIT;
-    validatePagination(page, limit);
-
-    const [scenarios, total] = await Promise.all([
-      testScenarioModel.findMany(params.projectId, page, limit),
-      testScenarioModel.count(params.projectId),
-    ]);
-
-    return {
-      scenarios,
-      total,
-      page,
-      limit,
-      totalPages: Math.ceil(total / limit),
-    };
-  },
-
-  async listScenarioSummaries(
-    params: ListTestScenariosParams,
-  ): Promise<TestScenarioSummaryListResponse> {
     const page = params.page ?? DEFAULT_PAGE;
     const limit = params.limit ?? DEFAULT_LIMIT;
     validatePagination(page, limit);
@@ -133,9 +123,13 @@ export const testScenarioService = {
       throw new TestScenarioValidationError("Project ID is required");
     }
 
-    if (params.title === undefined && params.contentMd === undefined) {
+    if (
+      params.title === undefined &&
+      params.contentMd === undefined &&
+      params.details === undefined
+    ) {
       throw new TestScenarioValidationError(
-        "At least one of title or contentMd is required",
+        "At least one of title, contentMd, or details is required",
       );
     }
 
@@ -153,6 +147,13 @@ export const testScenarioService = {
       throw new TestScenarioValidationError("contentMd is required");
     }
 
+    const details =
+      params.details === undefined
+        ? undefined
+        : params.details === null
+          ? null
+          : normalizeDetails(params.details);
+
     const scenario = await testScenarioModel.update(
       params.scenarioId,
       params.projectId,
@@ -161,6 +162,7 @@ export const testScenarioService = {
         ...(params.contentMd !== undefined
           ? { contentMd: params.contentMd }
           : {}),
+        ...(details !== undefined ? { details } : {}),
       },
     );
 

--- a/src/types/testScenarios.ts
+++ b/src/types/testScenarios.ts
@@ -12,17 +12,26 @@ export interface TestScenarioResponse {
   createdById: string;
   title: string;
   contentMd: string;
+  details: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export type TestScenarioRecord = TestScenarioResponse;
 
+export interface TestScenarioCreatorSummary {
+  id: string;
+  name: string;
+  email: string;
+}
+
 export interface TestScenarioSummary {
   id: string;
   projectId: string;
   createdById: string;
   title: string;
+  details: string | null;
+  createdBy: TestScenarioCreatorSummary;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -32,6 +41,7 @@ export interface CreateTestScenarioParams {
   title: string;
   contentMd: string;
   createdById: string;
+  details?: string | undefined;
 }
 
 export interface UpdateTestScenarioParams {
@@ -39,6 +49,7 @@ export interface UpdateTestScenarioParams {
   projectId: string;
   title?: string | undefined;
   contentMd?: string | undefined;
+  details?: string | null | undefined;
 }
 
 export interface ListTestScenariosParams {
@@ -48,20 +59,14 @@ export interface ListTestScenariosParams {
 }
 
 export interface TestScenarioListResponse {
-  scenarios: TestScenarioResponse[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-}
-
-export interface TestScenarioSummaryListResponse {
   scenarios: TestScenarioSummary[];
   total: number;
   page: number;
   limit: number;
   totalPages: number;
 }
+
+export type TestScenarioSummaryListResponse = TestScenarioListResponse;
 
 export type TestScenarioMcpListParams = ListTestScenariosParams;
 


### PR DESCRIPTION
## Summary

- add nullable plain-text details metadata to Test Scenarios
- replace REST and MCP list payloads with one lightweight summary projection
- expose safe creator metadata with id, name, and email while retaining createdById
- exclude contentMd from list queries and preserve exact Markdown on detail responses
- align Prisma, service, REST, MCP, OpenAPI, documentation, and regression coverage

## Compatibility

GET /api/v2/test-scenarios now returns summary items without contentMd. Dependent clients should regenerate from the updated OpenAPI document and request scenario detail when Markdown is required.

## Verification

- npm run type-check
- npm run lint (passes with two existing warnings)
- npm test -- --runInBand: 83 suites, 595 tests
- npm run build
- npx openspec validate add-test-scenario-summaries --type change --strict --no-interactive
- git diff --check

Closes #84
Closes #85
Related to #90